### PR TITLE
Cleanup RGB scope scaling for 0-255 range

### DIFF
--- a/src/audio-align/audioalignmentdialog.cpp
+++ b/src/audio-align/audioalignmentdialog.cpp
@@ -86,6 +86,9 @@ AudioAlignmentDialog::AudioAlignmentDialog(QWidget *parent) :
     if (ui->loadTracksForExportLabel) {
         ui->loadTracksForExportLabel->setToolTip(loadTracksForExportTooltip);
     }
+    if (ui->cancelButton) {
+        ui->cancelButton->setToolTip(tr("Force stop the currently running alignment process."));
+    }
 
     if (ui->statusLabel) {
         ui->statusLabel->setText(tr("Using internal AAA workflow (ffprobe + ffmpeg + VhsDecodeAutoAudioAlign)."));
@@ -162,6 +165,10 @@ void AudioAlignmentDialog::setAlignmentUiBusy(bool busy)
         ui->alignButton->setEnabled(enabled);
         ui->alignButton->setText(busy ? tr("Aligning...") : tr("Align"));
     }
+    if (ui->cancelButton) {
+        ui->cancelButton->setEnabled(busy);
+        ui->cancelButton->setText(tr("Cancel / Force Stop"));
+    }
 }
 
 void AudioAlignmentDialog::startAlignmentRun(const QString &jsonFileName,
@@ -177,6 +184,7 @@ void AudioAlignmentDialog::startAlignmentRun(const QString &jsonFileName,
         return;
     }
 
+    alignmentCancelRequested.store(false, std::memory_order_relaxed);
     setAlignmentUiBusy(true);
 
     QPointer<AudioAlignmentDialog> self(this);
@@ -185,6 +193,9 @@ void AudioAlignmentDialog::startAlignmentRun(const QString &jsonFileName,
         runResult.success = true;
         const int totalTracks = qMax(1, static_cast<int>(trackRequests.size()));
         int completedTracks = 0;
+        auto cancellationRequested = [self]() -> bool {
+            return !self || self->alignmentCancelRequested.load(std::memory_order_relaxed);
+        };
 
         auto postStatus = [self](const QString &statusText) {
             if (!self) {
@@ -216,6 +227,12 @@ void AudioAlignmentDialog::startAlignmentRun(const QString &jsonFileName,
         };
 
         for (const AlignmentTrackRequest &trackRequest : trackRequests) {
+            if (cancellationRequested()) {
+                runResult.success = false;
+                runResult.cancelled = true;
+                runResult.errorMessage = QObject::tr("Operation cancelled by user.");
+                break;
+            }
             updateProgressStatus(trackRequest.trackLabel, 0, QString());
 
             QString trackErrorMessage;
@@ -228,11 +245,17 @@ void AudioAlignmentDialog::startAlignmentRun(const QString &jsonFileName,
                 [&](int stagePercent, const QString &stageMessage) {
                     updateProgressStatus(trackRequest.trackLabel, stagePercent, stageMessage);
                 },
+                cancellationRequested,
                 &trackErrorMessage);
             if (!success) {
                 runResult.success = false;
-                runResult.failureTrackLabel = trackRequest.trackLabel;
                 runResult.errorMessage = trackErrorMessage;
+                runResult.cancelled = cancellationRequested()
+                                      || trackErrorMessage.contains(QStringLiteral("cancelled"),
+                                                                    Qt::CaseInsensitive);
+                if (!runResult.cancelled) {
+                    runResult.failureTrackLabel = trackRequest.trackLabel;
+                }
                 break;
             }
 
@@ -281,6 +304,14 @@ void AudioAlignmentDialog::finishAlignmentRun(const AlignmentRunResult &result)
 {
     QApplication::restoreOverrideCursor();
     setAlignmentUiBusy(false);
+    alignmentCancelRequested.store(false, std::memory_order_relaxed);
+
+    if (result.cancelled) {
+        if (ui && ui->statusLabel) {
+            ui->statusLabel->setText(tr("Alignment cancelled."));
+        }
+        return;
+    }
 
     if (!result.success) {
         const QString failedTrackLabel = result.failureTrackLabel.isEmpty()
@@ -356,6 +387,7 @@ void AudioAlignmentDialog::finishAlignmentRun(const AlignmentRunResult &result)
 AudioAlignmentDialog::~AudioAlignmentDialog()
 {
     if (alignmentWorkerThread) {
+        alignmentCancelRequested.store(true, std::memory_order_relaxed);
         alignmentWorkerThread->wait();
         delete alignmentWorkerThread;
         alignmentWorkerThread = nullptr;
@@ -367,7 +399,10 @@ void AudioAlignmentDialog::closeEvent(QCloseEvent *event)
 {
     if (alignmentInProgress) {
         if (ui && ui->statusLabel) {
-            ui->statusLabel->setText(tr("Alignment is currently running. Please wait for completion."));
+            const bool stopRequested = alignmentCancelRequested.load(std::memory_order_relaxed);
+            ui->statusLabel->setText(stopRequested
+                                         ? tr("Alignment stop requested. Please wait for the running process to exit.")
+                                         : tr("Alignment is currently running. Use Cancel / Force Stop to stop it."));
         }
         event->ignore();
         return;
@@ -687,6 +722,32 @@ void AudioAlignmentDialog::on_alignButton_clicked()
                       trackRequests,
                       ui->overwriteCheckBox && ui->overwriteCheckBox->isChecked(),
                       currentRfVideoSampleRateHz());
+}
+
+void AudioAlignmentDialog::on_cancelButton_clicked()
+{
+    if (!alignmentInProgress) {
+        if (ui && ui->statusLabel) {
+            ui->statusLabel->setText(tr("No alignment is currently running."));
+        }
+        return;
+    }
+
+    const bool alreadyRequested = alignmentCancelRequested.exchange(true, std::memory_order_relaxed);
+    if (alreadyRequested) {
+        if (ui && ui->statusLabel) {
+            ui->statusLabel->setText(tr("Force stop already requested. Waiting for the running process to exit..."));
+        }
+        return;
+    }
+
+    if (ui && ui->statusLabel) {
+        ui->statusLabel->setText(tr("Stopping alignment..."));
+    }
+    if (ui && ui->cancelButton) {
+        ui->cancelButton->setEnabled(false);
+        ui->cancelButton->setText(tr("Stopping..."));
+    }
 }
 
 void AudioAlignmentDialog::updateLinearOutputFromInput(bool forceOutputUpdate)

--- a/src/audio-align/audioalignmentdialog.h
+++ b/src/audio-align/audioalignmentdialog.h
@@ -15,6 +15,7 @@
 #include <QtGlobal>
 #include <QVector>
 #include <QStringList>
+#include <atomic>
 
 namespace Ui {
 class AudioAlignmentDialog;
@@ -48,6 +49,7 @@ private slots:
     void on_hifiInputBrowseButton_clicked();
     void on_hifiOutputBrowseButton_clicked();
     void on_alignButton_clicked();
+    void on_cancelButton_clicked();
 
 private:
     struct AlignmentTrackRequest {
@@ -58,6 +60,7 @@ private:
     };
     struct AlignmentRunResult {
         bool success = false;
+        bool cancelled = false;
         bool linearAligned = false;
         bool hifiAligned = false;
         QString linearOutputFile;
@@ -86,6 +89,7 @@ private:
     bool userEditedLinearOutput = false;
     bool userEditedHifiOutput = false;
     bool alignmentInProgress = false;
+    std::atomic_bool alignmentCancelRequested{false};
     QThread *alignmentWorkerThread = nullptr;
 };
 

--- a/src/audio-align/audioalignmentdialog.ui
+++ b/src/audio-align/audioalignmentdialog.ui
@@ -294,6 +294,16 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Cancel / Force Stop</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="alignButton">
        <property name="text">
         <string>Align</string>

--- a/src/audio-align/audioalignmentutil.cpp
+++ b/src/audio-align/audioalignmentutil.cpp
@@ -206,6 +206,7 @@ bool runProcess(const QString &program,
                 const QStringList &arguments,
                 const QString &workingDirectory,
                 const std::function<void(const QString &)> &outputLineCallback,
+                const AudioAlignmentUtil::CancelCallback &cancelCallback,
                 QString *combinedOutput,
                 QString *errorMessage)
 {
@@ -251,9 +252,44 @@ bool runProcess(const QString &program,
         }
     };
 
+    auto cancellationRequested = [&cancelCallback]() -> bool {
+        return cancelCallback && cancelCallback();
+    };
     while (process.state() != QProcess::NotRunning) {
+        if (cancellationRequested()) {
+            process.terminate();
+            if (!process.waitForFinished(1000)) {
+                process.kill();
+                process.waitForFinished(3000);
+            }
+            consumeChunk(process.readAllStandardOutput());
+            const QString cancelledOutput = QString::fromLocal8Bit(combinedOutputData).trimmed();
+            if (combinedOutput) {
+                *combinedOutput = cancelledOutput;
+            }
+            if (errorMessage) {
+                *errorMessage = QObject::tr("Operation cancelled by user.");
+                if (!cancelledOutput.isEmpty()) {
+                    *errorMessage += QStringLiteral("\n") + cancelledOutput;
+                }
+            }
+            return false;
+        }
         process.waitForReadyRead(100);
         consumeChunk(process.readAllStandardOutput());
+    }
+    if (cancellationRequested()) {
+        const QString cancelledOutput = QString::fromLocal8Bit(combinedOutputData).trimmed();
+        if (combinedOutput) {
+            *combinedOutput = cancelledOutput;
+        }
+        if (errorMessage) {
+            *errorMessage = QObject::tr("Operation cancelled by user.");
+            if (!cancelledOutput.isEmpty()) {
+                *errorMessage += QStringLiteral("\n") + cancelledOutput;
+            }
+        }
+        return false;
     }
     consumeChunk(process.readAllStandardOutput());
     if (!pendingOutputLine.trimmed().isEmpty() && outputLineCallback) {
@@ -291,7 +327,13 @@ bool detectAudioSampleRateHz(const QString &ffprobePath,
         QStringLiteral("-of"), QStringLiteral("default=noprint_wrappers=1:nokey=1"),
         inputFilename
     };
-    if (!runProcess(ffprobePath, arguments, QString(), {}, &output, &processError)) {
+    if (!runProcess(ffprobePath,
+                    arguments,
+                    QString(),
+                    {},
+                    AudioAlignmentUtil::CancelCallback(),
+                    &output,
+                    &processError)) {
         if (errorMessage) {
             *errorMessage = processError.isEmpty()
                 ? QObject::tr("Unable to detect audio sample rate using ffprobe.")
@@ -356,6 +398,24 @@ bool hasPreferredKeyword(const QString &audioBaseLower, AudioPreference preferen
     return true;
 }
 
+bool isBasebandStereoCh1Ch2Name(const QString &audioBaseLower)
+{
+    return audioBaseLower.contains(QStringLiteral("baseband_stereo_ch1_ch2"))
+        || (audioBaseLower.contains(QStringLiteral("baseband"))
+            && audioBaseLower.contains(QStringLiteral("stereo"))
+            && audioBaseLower.contains(QStringLiteral("ch1"))
+            && audioBaseLower.contains(QStringLiteral("ch2")));
+}
+
+bool isBasebandStereoCh3Ch4Name(const QString &audioBaseLower)
+{
+    return audioBaseLower.contains(QStringLiteral("baseband_stereo_ch3_ch4"))
+        || (audioBaseLower.contains(QStringLiteral("baseband"))
+            && audioBaseLower.contains(QStringLiteral("stereo"))
+            && audioBaseLower.contains(QStringLiteral("ch3"))
+            && audioBaseLower.contains(QStringLiteral("ch4")));
+}
+
 int audioCandidateScore(const QFileInfo &audioInfo,
                         const QStringList &rootCandidatesLower,
                         AudioPreference preference)
@@ -399,11 +459,17 @@ int audioCandidateScore(const QFileInfo &audioInfo,
     }
     switch (preference) {
     case AudioPreference::Linear:
+        if (isBasebandStereoCh1Ch2Name(audioBaseLower)) {
+            bestRootScore += 780;
+        }
         if (audioBaseLower.contains(QStringLiteral("linear"))) {
             bestRootScore += 340;
         }
         if (audioBaseLower.contains(QStringLiteral("baseband"))) {
             bestRootScore += 320;
+        }
+        if (isBasebandStereoCh3Ch4Name(audioBaseLower)) {
+            bestRootScore -= 220;
         }
         if (audioBaseLower.contains(QStringLiteral("hifi"))) {
             bestRootScore -= 260;
@@ -573,10 +639,23 @@ bool runStreamAlign(const QString &jsonFilename,
                     quint32 rfVideoSampleRateHz,
                     bool overwriteOutput,
                     const ProgressCallback &progressCallback,
+                    const CancelCallback &cancelCallback,
                     QString *errorMessage)
 {
     if (errorMessage) {
         errorMessage->clear();
+    }
+    auto cancellationRequested = [&cancelCallback]() -> bool {
+        return cancelCallback && cancelCallback();
+    };
+    auto setCancelledError = [errorMessage]() {
+        if (errorMessage) {
+            *errorMessage = QObject::tr("Operation cancelled by user.");
+        }
+    };
+    if (cancellationRequested()) {
+        setCancelledError();
+        return false;
     }
     emitProgress(progressCallback, 0, QObject::tr("Preparing alignment..."));
 
@@ -639,6 +718,10 @@ bool runStreamAlign(const QString &jsonFilename,
     if (!detectAudioSampleRateHz(ffprobePath, normalizedInput, &streamSampleRateHz, errorMessage)) {
         return false;
     }
+    if (cancellationRequested()) {
+        setCancelledError();
+        return false;
+    }
     emitProgress(progressCallback, 5, QObject::tr("Preparation complete."));
 
     QTemporaryDir temporaryDirectory;
@@ -673,6 +756,7 @@ bool runStreamAlign(const QString &jsonFilename,
                                          QObject::tr("Decoding input audio..."));
                         }
                     },
+                    cancelCallback,
                     &processOutput,
                     &processError)) {
         if (errorMessage) {
@@ -703,6 +787,7 @@ bool runStreamAlign(const QString &jsonFilename,
                                          QObject::tr("Aligning audio stream..."));
                         }
                     },
+                    cancelCallback,
                     &processOutput,
                     &processError)) {
         if (errorMessage) {
@@ -736,6 +821,7 @@ bool runStreamAlign(const QString &jsonFilename,
                                          QObject::tr("Encoding aligned output..."));
                         }
                     },
+                    cancelCallback,
                     &processOutput,
                     &processError)) {
         if (errorMessage) {

--- a/src/audio-align/audioalignmentutil.h
+++ b/src/audio-align/audioalignmentutil.h
@@ -17,6 +17,7 @@
 
 namespace AudioAlignmentUtil {
 using ProgressCallback = std::function<void(int percent, const QString &statusMessage)>;
+using CancelCallback = std::function<bool()>;
 QString normalizePathForCurrentPlatform(const QString &path);
 QString defaultAlignedOutputPath(const QString &inputFilename);
 QString autoDetectInputAudioFile(const QString &jsonFilename, const QString &excludeFile = QString());
@@ -28,6 +29,7 @@ bool runStreamAlign(const QString &jsonFilename,
                     quint32 rfVideoSampleRateHz,
                     bool overwriteOutput,
                     const ProgressCallback &progressCallback = ProgressCallback(),
+                    const CancelCallback &cancelCallback = CancelCallback(),
                     QString *errorMessage = nullptr);
 }
 

--- a/src/ld-analyse/CMakeLists.txt
+++ b/src/ld-analyse/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ld-analyse_SOURCES
     metadataconverterutil.cpp
     ../tbc-export-metadata/metadataexportdialog.cpp ../tbc-export-metadata/metadataexportdialog.h ../tbc-export-metadata/metadataexportdialog.ui
     oscilloscopedialog.cpp oscilloscopedialog.ui
+    rgbscopedialog.cpp rgbscopedialog.h
     vectorscopedialog.cpp vectorscopedialog.ui
     fieldtimingdialog.cpp fieldtimingdialog.h
     fieldtimingwidget.cpp fieldtimingwidget.h

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -1104,6 +1104,7 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
 
     // Set up dialogues
     oscilloscopeDialog = new OscilloscopeDialog(this);
+    rgbScopeDialog = new RgbScopeDialog(this);
     vectorscopeDialog = new VectorscopeDialog(this);
     fieldTimingDialog = new FieldTimingDialog(this);
     aboutDialog = new AboutDialog(this);
@@ -1245,6 +1246,12 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
 
     // Connect to the changed signal from the vectorscope dialogue
     connect(vectorscopeDialog, &VectorscopeDialog::scopeChanged, this, &MainWindow::vectorscopeChangedSignalHandler);
+    connect(rgbScopeDialog, &RgbScopeDialog::renderTargetSizeChanged, this, [this](const QSize &) {
+        if (!rgbScopeDialog || !rgbScopeDialog->isVisible() || rgbScopeDialog->isMinimized()) {
+            return;
+        }
+        updateRgbScopeDialogue(false);
+    });
 
     // Connect to the video parameters changed signal
     connect(videoParametersDialog, &VideoParametersDialog::videoParametersChanged, this, &MainWindow::videoParametersChangedSignalHandler);
@@ -1304,6 +1311,14 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
     resizeTimer->setSingleShot(true);
     resizeTimer->setInterval(100); // 100ms delay for resize calculations
     connect(resizeTimer, &QTimer::timeout, this, &MainWindow::resizeFrameToWindow);
+    rgbScopeRefreshTimer = new QTimer(this);
+    rgbScopeRefreshTimer->setSingleShot(true);
+    connect(rgbScopeRefreshTimer, &QTimer::timeout, this, [this]() {
+        rgbScopeRefreshPending = false;
+        if (rgbScopeDialog && rgbScopeDialog->isVisible()) {
+            updateRgbScopeDialogue(true);
+        }
+    });
     
     // Initialize chroma seek mode tracking
     chromaSeekMode = false;
@@ -1948,6 +1963,12 @@ void MainWindow::updateGuiUnloaded()
     videoParametersDialog->hide();
     chromaDecoderConfigDialog->hide();
     fieldTimingDialog->hide();
+    rgbScopeDialog->hide();
+    if (rgbScopeRefreshTimer) {
+        rgbScopeRefreshTimer->stop();
+    }
+    rgbScopeRefreshPending = false;
+    rgbScopeLastRefreshMs = 0;
     updateTimelineMarkers();
     updateNotesViewerState();
 
@@ -2285,6 +2306,9 @@ void MainWindow::updateImage()
     // If the scope dialogues are open, update them
     if (oscilloscopeDialog->isVisible()) {
         updateOscilloscopeDialogue();
+    }
+    if (rgbScopeDialog->isVisible() && !rgbScopeDialog->isMinimized()) {
+        updateRgbScopeDialogue();
     }
     if (vectorscopeDialog->isVisible()) {
         updateVectorscopeDialogue();
@@ -2976,6 +3000,36 @@ void MainWindow::updateOscilloscopeDialogue()
     oscilloscopeDialog->showTraceImage(tbcSource.getScanLineData(lastScopeLine),
                                        lastScopeDot, lastScopeLine - 1,
                                        tbcSource.getFrameWidth(), tbcSource.getFrameHeight(), tbcSource.getSourceMode() == TbcSource::SourceMode::BOTH_SOURCES);
+}
+
+void MainWindow::updateRgbScopeDialogue(bool force)
+{
+    if (!rgbScopeDialog || !tbcSource.getIsSourceLoaded() || tbcSource.getIsMetadataOnly()) {
+        return;
+    }
+    if (asyncFrameRenderInProgress && shouldRenderFrameAsync()) {
+        return;
+    }
+
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 minRefreshIntervalMs = playbackRunning ? 180 : 80;
+    if (!force && rgbScopeLastRefreshMs > 0) {
+        const qint64 elapsedMs = nowMs - rgbScopeLastRefreshMs;
+        if (elapsedMs < minRefreshIntervalMs) {
+            if (rgbScopeRefreshTimer && !rgbScopeRefreshPending) {
+                rgbScopeRefreshPending = true;
+                rgbScopeRefreshTimer->start(static_cast<int>(minRefreshIntervalMs - elapsedMs));
+            }
+            return;
+        }
+    }
+
+    rgbScopeDialog->showScopeImage(tbcSource.getRgbScopeImage(rgbScopeDialog->scopeRenderTargetSize()));
+    rgbScopeLastRefreshMs = nowMs;
+    if (rgbScopeRefreshTimer && rgbScopeRefreshPending) {
+        rgbScopeRefreshTimer->stop();
+        rgbScopeRefreshPending = false;
+    }
 }
 
 // Method to update the vectorscope
@@ -4433,17 +4487,18 @@ void MainWindow::on_actionVectorscope_triggered()
     }
 }
 
-// Display RGB scope in the main viewer
+// Display the RGB scope pop-out view
 void MainWindow::on_actionRGB_scope_triggered()
 {
     if (!tbcSource.getIsSourceLoaded() || tbcSource.getIsMetadataOnly()) {
         return;
     }
-
-    tbcSource.setViewMode(TbcSource::ViewMode::RGB_SCOPE_VIEW);
-    tbcSource.setStretchField(false);
-    setViewValues();
-    showImage();
+    if (!rgbScopeDialog->isVisible()) {
+        rgbScopeDialog->show();
+    }
+    updateRgbScopeDialogue(true);
+    rgbScopeDialog->raise();
+    rgbScopeDialog->activateWindow();
 }
 // Display the field timing scope view
 void MainWindow::on_actionField_timing_scope_triggered()

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -1476,6 +1476,7 @@ void MainWindow::setGuiEnabled(bool enabled)
 
     // Enable menu options
     ui->actionLine_scope->setEnabled(enabled);
+    ui->actionRGB_scope->setEnabled(enabled);
     ui->actionVectorscope->setEnabled(enabled);
     ui->actionField_timing_scope->setEnabled(enabled);
     ui->actionVBI->setEnabled(enabled);
@@ -1839,6 +1840,7 @@ void MainWindow::updateGuiLoaded()
     if (metadataOnly) {
         ui->actionSave_frame_as_PNG->setEnabled(false);
         ui->actionLine_scope->setEnabled(false);
+        ui->actionRGB_scope->setEnabled(false);
         ui->actionVectorscope->setEnabled(false);
         ui->actionField_timing_scope->setEnabled(false);
     }
@@ -2586,6 +2588,8 @@ QVector<QRect> MainWindow::getActiveVideoRects() const
         }
         break;
     }
+    case TbcSource::ViewMode::RGB_SCOPE_VIEW:
+        break;
     }
 
     return rects;
@@ -3280,10 +3284,16 @@ void MainWindow::setViewValues()
 {
     qint32 currentNumber, maximum;
     QString buttonLabel, spinLabel;
+    const bool rgbScopeView = tbcSource.getRgbScopeViewEnabled();
 
 	if (this->width() >= 930)
 	{
-		if (tbcSource.getFieldViewEnabled()) {
+		if (rgbScopeView) {
+			currentNumber = currentFrameNumber;
+			maximum = tbcSource.getNumberOfFrames();
+			spinLabel = QString("Frame #:");
+			buttonLabel = QString("RGB Scope");
+		} else if (tbcSource.getFieldViewEnabled()) {
 			currentNumber = currentFieldNumber;
 			maximum = tbcSource.getNumberOfFields();
 			spinLabel = QString("Field #:");
@@ -3306,7 +3316,12 @@ void MainWindow::setViewValues()
 	}
 	else
 	{
-		if (tbcSource.getFieldViewEnabled()) {
+		if (rgbScopeView) {
+			currentNumber = currentFrameNumber;
+			maximum = tbcSource.getNumberOfFrames();
+			spinLabel = QString("Frame #:");
+			buttonLabel = QString("RGB");
+		} else if (tbcSource.getFieldViewEnabled()) {
 			currentNumber = currentFieldNumber;
 			maximum = tbcSource.getNumberOfFields();
 			spinLabel = QString("Field #:");
@@ -4418,6 +4433,18 @@ void MainWindow::on_actionVectorscope_triggered()
     }
 }
 
+// Display RGB scope in the main viewer
+void MainWindow::on_actionRGB_scope_triggered()
+{
+    if (!tbcSource.getIsSourceLoaded() || tbcSource.getIsMetadataOnly()) {
+        return;
+    }
+
+    tbcSource.setViewMode(TbcSource::ViewMode::RGB_SCOPE_VIEW);
+    tbcSource.setStretchField(false);
+    setViewValues();
+    showImage();
+}
 // Display the field timing scope view
 void MainWindow::on_actionField_timing_scope_triggered()
 {
@@ -4527,6 +4554,10 @@ void MainWindow::on_actionSave_frame_as_PNG_triggered()
 
     case TbcSource::ViewMode::FIELD_VIEW:
         filenameStem += tr("field_");
+        break;
+
+    case TbcSource::ViewMode::RGB_SCOPE_VIEW:
+        filenameStem += tr("rgb_scope_");
         break;
     }
 
@@ -4728,7 +4759,8 @@ void MainWindow::on_actionSave_all_modes_as_PNGs_triggered()
         {QStringLiteral("frame"), TbcSource::ViewMode::FRAME_VIEW, false},
         {QStringLiteral("split"), TbcSource::ViewMode::SPLIT_VIEW, false},
         {QStringLiteral("field_1x"), TbcSource::ViewMode::FIELD_VIEW, false},
-        {QStringLiteral("field_2x"), TbcSource::ViewMode::FIELD_VIEW, true}
+        {QStringLiteral("field_2x"), TbcSource::ViewMode::FIELD_VIEW, true},
+        {QStringLiteral("rgb_scope"), TbcSource::ViewMode::RGB_SCOPE_VIEW, false}
     };
 
     int savedCount = 0;
@@ -5438,11 +5470,19 @@ void MainWindow::on_viewPushButton_clicked()
                 // Set field mode with 2:1 aspect
                 tbcSource.setStretchField(true);
             } else {
-                tbcDebugStream() << "Changing to FRAME_VIEW mode";
+                tbcDebugStream() << "Changing to RGB_SCOPE_VIEW mode";
 
-                // Set frame mode
-                tbcSource.setViewMode(TbcSource::ViewMode::FRAME_VIEW);
+                // Set RGB scope mode
+                tbcSource.setViewMode(TbcSource::ViewMode::RGB_SCOPE_VIEW);
+                tbcSource.setStretchField(false);
             }
+            break;
+
+        case TbcSource::ViewMode::RGB_SCOPE_VIEW:
+            tbcDebugStream() << "Changing to FRAME_VIEW mode";
+
+            // Set frame mode
+            tbcSource.setViewMode(TbcSource::ViewMode::FRAME_VIEW);
             break;
     }
 
@@ -6265,7 +6305,9 @@ void MainWindow::resizeEvent(QResizeEvent *event)
 				ui->viewPushButton->setText(tr("Field 1:1"));
 			}
 		} else {
-			if (tbcSource.getSplitViewEnabled()) {
+			if (tbcSource.getRgbScopeViewEnabled()) {
+				ui->viewPushButton->setText(tr("RGB Scope"));
+			} else if (tbcSource.getSplitViewEnabled()) {
 				ui->viewPushButton->setText(tr("Split View"));
 			} else {
 				ui->viewPushButton->setText(tr("Frame View"));
@@ -6281,7 +6323,9 @@ void MainWindow::resizeEvent(QResizeEvent *event)
 				ui->viewPushButton->setText(tr("Field 1:1"));
 			}
 		} else {
-			if (tbcSource.getSplitViewEnabled()) {
+			if (tbcSource.getRgbScopeViewEnabled()) {
+				ui->viewPushButton->setText(tr("RGB"));
+			} else if (tbcSource.getSplitViewEnabled()) {
 				ui->viewPushButton->setText(tr("Split"));
 			} else {
 				ui->viewPushButton->setText(tr("Frame"));

--- a/src/ld-analyse/mainwindow.h
+++ b/src/ld-analyse/mainwindow.h
@@ -34,6 +34,7 @@
 #include <QFutureWatcher>
 
 #include "oscilloscopedialog.h"
+#include "rgbscopedialog.h"
 #include "vectorscopedialog.h"
 #include "fieldtimingdialog.h"
 #include "aboutdialog.h"
@@ -199,6 +200,7 @@ private:
 
     // Dialogues
     OscilloscopeDialog* oscilloscopeDialog;
+    RgbScopeDialog *rgbScopeDialog;
     VectorscopeDialog* vectorscopeDialog;
     FieldTimingDialog* fieldTimingDialog;
     AboutDialog* aboutDialog;
@@ -250,6 +252,9 @@ private:
     QTimer* resizeTimer = nullptr;
     double playbackTickCarryMs = 0.0;
     bool playbackRunning = false;
+    QTimer* rgbScopeRefreshTimer = nullptr;
+    bool rgbScopeRefreshPending = false;
+    qint64 rgbScopeLastRefreshMs = 0;
     
     // Chroma toggle during seek
     bool chromaSeekMode;
@@ -313,6 +318,7 @@ private:
     void loadTbcFile(QString inputFileName, bool forceMetadataOnly = false, bool preserveStatusDuringReload = false);
     void cleanupTempMetadataFile();
     void updateOscilloscopeDialogue();
+    void updateRgbScopeDialogue(bool force = false);
     void updateVectorscopeDialogue();
     void updateFieldTimingDialogue();
     void populateThemesMenu();

--- a/src/ld-analyse/mainwindow.h
+++ b/src/ld-analyse/mainwindow.h
@@ -78,6 +78,7 @@ private slots:
     void on_actionMetadata_Status_triggered();
     void on_actionSave_Metadata_triggered();
     void on_actionLine_scope_triggered();
+    void on_actionRGB_scope_triggered();
     void on_actionVectorscope_triggered();
     void on_actionField_timing_scope_triggered();
     void on_actionTBC_Tools_Wiki_triggered();

--- a/src/ld-analyse/mainwindow.ui
+++ b/src/ld-analyse/mainwindow.ui
@@ -765,6 +765,7 @@
     </property>
     <addaction name="actionVectorscope"/>
     <addaction name="actionLine_scope"/>
+    <addaction name="actionRGB_scope"/>
     <addaction name="actionField_timing_scope"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -892,6 +893,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
+   </property>
+  </action>
+  <action name="actionRGB_scope">
+   <property name="text">
+    <string>RGB scope...</string>
    </property>
   </action>
   <action name="actionVectorscope">

--- a/src/ld-analyse/rgbscopedialog.cpp
+++ b/src/ld-analyse/rgbscopedialog.cpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * rgbscopedialog.cpp
+ * ld-analyse - TBC output analysis GUI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This file is part of ld-decode-tools.
+ ******************************************************************************/
+
+#include "rgbscopedialog.h"
+
+#include <QLabel>
+#include <QPixmap>
+#include <QResizeEvent>
+#include <QSizePolicy>
+#include <QVBoxLayout>
+
+RgbScopeDialog::RgbScopeDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("RGB Scope"));
+    setWindowFlags(Qt::Window);
+    setModal(false);
+    resize(960, 540);
+
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(6, 6, 6, 6);
+    mainLayout->setSpacing(0);
+
+    scopeLabel_ = new QLabel(this);
+    scopeLabel_->setAlignment(Qt::AlignCenter);
+    scopeLabel_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    scopeLabel_->setScaledContents(false);
+    scopeLabel_->setText(tr("No RGB scope data"));
+    mainLayout->addWidget(scopeLabel_);
+}
+
+void RgbScopeDialog::showScopeImage(const QImage &scopeImage)
+{
+    cachedScopeImage_ = scopeImage;
+    updateScopeLabelPixmap();
+}
+
+QSize RgbScopeDialog::scopeRenderTargetSize() const
+{
+    if (scopeLabel_) {
+        return scopeLabel_->size().expandedTo(QSize(1, 1));
+    }
+    return size().expandedTo(QSize(1, 1));
+}
+
+void RgbScopeDialog::resizeEvent(QResizeEvent *event)
+{
+    QDialog::resizeEvent(event);
+    updateScopeLabelPixmap();
+    emit renderTargetSizeChanged(scopeRenderTargetSize());
+}
+
+void RgbScopeDialog::updateScopeLabelPixmap()
+{
+    if (!scopeLabel_) {
+        return;
+    }
+
+    if (cachedScopeImage_.isNull()) {
+        scopeLabel_->setPixmap(QPixmap());
+        scopeLabel_->setText(tr("No RGB scope data"));
+        return;
+    }
+
+    const QSize targetSize = scopeLabel_->size().expandedTo(QSize(1, 1));
+    const QPixmap pixmap = QPixmap::fromImage(cachedScopeImage_).scaled(
+        targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scopeLabel_->setText(QString());
+    scopeLabel_->setPixmap(pixmap);
+}

--- a/src/ld-analyse/rgbscopedialog.h
+++ b/src/ld-analyse/rgbscopedialog.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * rgbscopedialog.h
+ * ld-analyse - TBC output analysis GUI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This file is part of ld-decode-tools.
+ ******************************************************************************/
+
+#ifndef RGBSCOPEDIALOG_H
+#define RGBSCOPEDIALOG_H
+
+#include <QDialog>
+#include <QImage>
+#include <QSize>
+
+class QLabel;
+class QResizeEvent;
+
+class RgbScopeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit RgbScopeDialog(QWidget *parent = nullptr);
+    ~RgbScopeDialog() override = default;
+
+    void showScopeImage(const QImage &scopeImage);
+    QSize scopeRenderTargetSize() const;
+
+signals:
+    void renderTargetSizeChanged(const QSize &targetSize);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    void updateScopeLabelPixmap();
+
+    QLabel *scopeLabel_ = nullptr;
+    QImage cachedScopeImage_;
+};
+
+#endif // RGBSCOPEDIALOG_H

--- a/src/ld-analyse/tbcsource.cpp
+++ b/src/ld-analyse/tbcsource.cpp
@@ -79,6 +79,16 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
     QImage scopeImage(scopeWidth, scopeHeight, QImage::Format_RGB32);
     scopeImage.fill(Qt::black);
 
+    const qint32 leftAxisWidth = qBound<qint32>(20, scopeWidth / 11, 64);
+    const qint32 rightPadding = qBound<qint32>(4, scopeWidth / 64, 16);
+    const qint32 topPadding = qBound<qint32>(12, scopeHeight / 14, 52);
+    const qint32 bottomPadding = qBound<qint32>(10, scopeHeight / 12, 48);
+    const QRect plotRect(leftAxisWidth,
+                         topPadding,
+                         qMax<qint32>(1, scopeWidth - leftAxisWidth - rightPadding),
+                         qMax<qint32>(1, scopeHeight - topPadding - bottomPadding));
+    const qint32 plotHeight = qMax<qint32>(1, plotRect.height());
+
     qint32 sourceXStart = qBound<qint32>(0, videoParameters.activeVideoStart, frameWidth - 1);
     qint32 sourceXEnd = qBound<qint32>(sourceXStart + 1, videoParameters.activeVideoEnd, frameWidth);
     qint32 sourceYStart = qBound<qint32>(0, videoParameters.firstActiveFrameLine, frameHeight - 1);
@@ -107,9 +117,18 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
     const qint32 sourceWidth = qMax<qint32>(1, sourceXEnd - sourceXStart);
     const qint32 sourceHeight = qMax<qint32>(1, sourceYEnd - sourceYStart);
     const qint32 xDenominator = qMax<qint32>(1, sourceWidth - 1);
-    const qint32 channelRenderWidth = qMax<qint32>(1, scopeWidth / 3);
+    const qint32 channelRenderWidth = qMax<qint32>(1, plotRect.width() / 3);
     const qint32 sampleStepX = qMax<qint32>(1, sourceWidth / channelRenderWidth);
-    const qint32 sampleStepY = qMax<qint32>(1, sourceHeight / qMax<qint32>(1, scopeHeight * 2));
+    const qint32 sampleStepY = qMax<qint32>(1, sourceHeight / qMax<qint32>(1, plotHeight * 2));
+
+    auto mapCodeValueToY = [&](qint32 value) {
+        const qint32 clamped = qBound<qint32>(0, value, 255);
+        if (plotHeight <= 1) {
+            return plotRect.top();
+        }
+        const qint32 localY = (plotHeight - 1) - ((clamped * (plotHeight - 1)) / 255);
+        return plotRect.top() + localY;
+    };
 
     struct WaveformChannel {
         qint32 startX = 0;
@@ -118,12 +137,12 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
     };
     std::array<WaveformChannel, 3> waveformChannels;
     for (qint32 channel = 0; channel < 3; ++channel) {
-        const qint32 channelStart = (channel * scopeWidth) / 3;
-        const qint32 channelEnd = ((channel + 1) * scopeWidth) / 3;
+        const qint32 channelStart = plotRect.left() + ((channel * plotRect.width()) / 3);
+        const qint32 channelEnd = plotRect.left() + (((channel + 1) * plotRect.width()) / 3);
         WaveformChannel &waveformChannel = waveformChannels[static_cast<size_t>(channel)];
         waveformChannel.startX = channelStart;
         waveformChannel.width = qMax<qint32>(1, channelEnd - channelStart);
-        waveformChannel.bins.fill(0, waveformChannel.width * scopeHeight);
+        waveformChannel.bins.fill(0, waveformChannel.width * plotHeight);
     }
 
     auto channelValueAt = [](QRgb pixel, qint32 channel) -> qint32 {
@@ -145,7 +164,7 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
                     ? 0
                     : ((sourceOffsetX * (waveformChannel.width - 1)) / xDenominator);
                 const qint32 value = channelValueAt(sourcePixel, channel);
-                const qint32 mappedY = (scopeHeight - 1) - ((value * (scopeHeight - 1)) / 255);
+                const qint32 mappedY = mapCodeValueToY(value) - plotRect.top();
                 quint16 &binValue = waveformChannel.bins[(mappedY * waveformChannel.width) + localX];
                 if (binValue < std::numeric_limits<quint16>::max()) {
                     ++binValue;
@@ -162,10 +181,10 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
     for (qint32 channel = 0; channel < 3; ++channel) {
         const WaveformChannel &waveformChannel = waveformChannels[static_cast<size_t>(channel)];
         const QColor channelColor = waveformColors[static_cast<size_t>(channel)];
-        for (qint32 yPosition = 0; yPosition < scopeHeight; ++yPosition) {
-            QRgb *scanLine = reinterpret_cast<QRgb *>(scopeImage.scanLine(yPosition));
+        for (qint32 localY = 0; localY < plotHeight; ++localY) {
+            QRgb *scanLine = reinterpret_cast<QRgb *>(scopeImage.scanLine(plotRect.top() + localY));
             for (qint32 localX = 0; localX < waveformChannel.width; ++localX) {
-                const quint16 density = waveformChannel.bins[(yPosition * waveformChannel.width) + localX];
+                const quint16 density = waveformChannel.bins[(localY * waveformChannel.width) + localX];
                 if (density == 0) {
                     continue;
                 }
@@ -191,38 +210,50 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
 
     scopePainter.setCompositionMode(QPainter::CompositionMode_SourceOver);
     scopePainter.setPen(QPen(QColor(150, 150, 150), 1));
-    scopePainter.drawRect(0, 0, scopeWidth - 1, scopeHeight - 1);
-    scopePainter.drawLine(scopeWidth / 3, 0, scopeWidth / 3, scopeHeight - 1);
-    scopePainter.drawLine((scopeWidth * 2) / 3, 0, (scopeWidth * 2) / 3, scopeHeight - 1);
+    scopePainter.drawRect(plotRect.adjusted(0, 0, -1, -1));
+    scopePainter.drawLine(plotRect.left() + (plotRect.width() / 3),
+                          plotRect.top(),
+                          plotRect.left() + (plotRect.width() / 3),
+                          plotRect.bottom());
+    scopePainter.drawLine(plotRect.left() + ((plotRect.width() * 2) / 3),
+                          plotRect.top(),
+                          plotRect.left() + ((plotRect.width() * 2) / 3),
+                          plotRect.bottom());
 
-    auto mapCodeValueToY = [scopeHeight](qint32 value) {
-        const qint32 clamped = qBound<qint32>(0, value, 255);
-        return (scopeHeight - 1) - ((clamped * (scopeHeight - 1)) / 255);
-    };
-    const qint32 yStudioBlack = mapCodeValueToY(16);
-    const qint32 yStudioWhite = mapCodeValueToY(235);
+    const std::array<qint32, 5> rangeGuideValues = { 0, 64, 128, 192, 255 };
+    for (const qint32 value : rangeGuideValues) {
+        const bool majorGuide = (value == 0 || value == 128 || value == 255);
+        scopePainter.setPen(QPen(majorGuide ? QColor(110, 110, 110) : QColor(80, 80, 80), 1));
+        const qint32 yPosition = mapCodeValueToY(value);
+        scopePainter.drawLine(plotRect.left(), yPosition, plotRect.right(), yPosition);
+    }
 
-    scopePainter.setPen(QPen(QColor(190, 190, 190), 1, Qt::DashLine));
-    scopePainter.drawLine(0, yStudioBlack, scopeWidth - 1, yStudioBlack);
-    scopePainter.drawLine(0, yStudioWhite, scopeWidth - 1, yStudioWhite);
+    const std::array<qint32, 2> legalRangeMarkers = { 16, 235 };
+    scopePainter.setPen(QPen(QColor(150, 150, 150, 200), 1, Qt::DashLine));
+    for (const qint32 value : legalRangeMarkers) {
+        const qint32 yPosition = mapCodeValueToY(value);
+        scopePainter.drawLine(plotRect.left(), yPosition, plotRect.right(), yPosition);
+    }
 
-    QFont levelFont = scopePainter.font();
-    levelFont.setPointSize(qMax<qint32>(7, scopeHeight / 42));
-    scopePainter.setFont(levelFont);
-    const QColor levelColor(200, 200, 200);
-    auto drawLevelLabel = [&](qint32 yPosition, const QString &text) {
-        scopePainter.setPen(levelColor);
-        const qint32 baselineY = qBound<qint32>(10, yPosition + 4, scopeHeight - 2);
-        const qint32 labelX = qMax<qint32>(8, scopeWidth - 48);
-        scopePainter.drawText(labelX, baselineY, text);
-    };
-    drawLevelLabel(yStudioWhite, QStringLiteral("235"));
-    drawLevelLabel(yStudioBlack, QStringLiteral("16"));
+    QFont axisFont = scopePainter.font();
+    axisFont.setPointSize(qMax<qint32>(7, scopeHeight / 42));
+    scopePainter.setFont(axisFont);
+    const qint32 axisLabelWidth = qMax<qint32>(10, leftAxisWidth - 6);
+    for (const qint32 value : rangeGuideValues) {
+        const qint32 yPosition = mapCodeValueToY(value);
+        scopePainter.setPen(QColor(205, 205, 205));
+        scopePainter.drawText(QRect(2, yPosition - 8, axisLabelWidth, 16),
+                              Qt::AlignRight | Qt::AlignVCenter,
+                              QString::number(value));
+    }
 
-    scopePainter.setPen(QColor(160, 160, 160));
-    scopePainter.drawText(QRect(8, scopeHeight - 20, qMax<qint32>(20, scopeWidth - 64), 16),
+    scopePainter.setPen(QColor(170, 170, 170));
+    scopePainter.drawText(QRect(plotRect.left(),
+                                qMax<qint32>(0, scopeHeight - bottomPadding),
+                                plotRect.width(),
+                                bottomPadding),
                           Qt::AlignLeft | Qt::AlignVCenter,
-                          QStringLiteral("Legal range 16-235"));
+                          QStringLiteral("8-bit range 0-255"));
 
     QFont labelFont = scopePainter.font();
     labelFont.setPointSize(qMax<qint32>(8, scopeHeight / 36));
@@ -237,11 +268,14 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
     };
 
     for (qint32 channel = 0; channel < 3; ++channel) {
-        const qint32 channelStart = (channel * scopeWidth) / 3;
-        const qint32 channelEnd = ((channel + 1) * scopeWidth) / 3;
+        const qint32 channelStart = plotRect.left() + ((channel * plotRect.width()) / 3);
+        const qint32 channelEnd = plotRect.left() + (((channel + 1) * plotRect.width()) / 3);
         scopePainter.setPen(labelColors[static_cast<size_t>(channel)]);
-        scopePainter.drawText(QRect(channelStart + 6, 6, qMax<qint32>(8, channelEnd - channelStart - 12), 28),
-                              Qt::AlignLeft | Qt::AlignTop,
+        scopePainter.drawText(QRect(channelStart,
+                                    2,
+                                    qMax<qint32>(8, channelEnd - channelStart),
+                                    qMax<qint32>(10, topPadding - 2)),
+                              Qt::AlignHCenter | Qt::AlignVCenter,
                               labels[static_cast<size_t>(channel)]);
     }
 

--- a/src/ld-analyse/tbcsource.cpp
+++ b/src/ld-analyse/tbcsource.cpp
@@ -9,6 +9,8 @@
  * This file is part of ld-decode-tools.
  ******************************************************************************/
 
+#include <array>
+#include <cmath>
 #include <limits>
 #include <QDir>
 #include <QDateTime>
@@ -57,6 +59,194 @@ void applyFullFrameDecodeBounds(LdDecodeMetaData::VideoParameters &videoParamete
     videoParameters.lastActiveFieldLine = videoParameters.fieldHeight;
     videoParameters.firstActiveFrameLine = 0;
     videoParameters.lastActiveFrameLine = frameHeight;
+}
+
+QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
+                                 qint32 frameWidth,
+                                 qint32 frameHeight,
+                                 const LdDecodeMetaData::VideoParameters &videoParameters,
+                                 const QSize &targetSize)
+{
+    if (frameWidth <= 0 || frameHeight <= 0 || rgbData.size() < (frameWidth * frameHeight)) {
+        return QImage();
+    }
+
+    const qint32 requestedWidth = targetSize.width() > 0 ? targetSize.width() : frameWidth;
+    const qint32 requestedHeight = targetSize.height() > 0 ? targetSize.height() : frameHeight;
+    const qint32 scopeWidth = qBound<qint32>(192, requestedWidth, 2048);
+    const qint32 scopeHeight = qBound<qint32>(120, requestedHeight, 1536);
+
+    QImage scopeImage(scopeWidth, scopeHeight, QImage::Format_RGB32);
+    scopeImage.fill(Qt::black);
+
+    qint32 sourceXStart = qBound<qint32>(0, videoParameters.activeVideoStart, frameWidth - 1);
+    qint32 sourceXEnd = qBound<qint32>(sourceXStart + 1, videoParameters.activeVideoEnd, frameWidth);
+    qint32 sourceYStart = qBound<qint32>(0, videoParameters.firstActiveFrameLine, frameHeight - 1);
+    qint32 sourceYEnd = qBound<qint32>(sourceYStart + 1, videoParameters.lastActiveFrameLine, frameHeight);
+
+    if (sourceXEnd <= sourceXStart) {
+        sourceXStart = 0;
+        sourceXEnd = frameWidth;
+    }
+    if (sourceYEnd <= sourceYStart) {
+        sourceYStart = 0;
+        sourceYEnd = frameHeight;
+    }
+
+    const qint32 minWaveformWidth = qMax<qint32>(64, frameWidth / 8);
+    if ((sourceXEnd - sourceXStart) < minWaveformWidth) {
+        sourceXStart = 0;
+        sourceXEnd = frameWidth;
+    }
+    const qint32 minWaveformHeight = qMax<qint32>(32, frameHeight / 8);
+    if ((sourceYEnd - sourceYStart) < minWaveformHeight) {
+        sourceYStart = 0;
+        sourceYEnd = frameHeight;
+    }
+
+    const qint32 sourceWidth = qMax<qint32>(1, sourceXEnd - sourceXStart);
+    const qint32 sourceHeight = qMax<qint32>(1, sourceYEnd - sourceYStart);
+    const qint32 xDenominator = qMax<qint32>(1, sourceWidth - 1);
+    const qint32 channelRenderWidth = qMax<qint32>(1, scopeWidth / 3);
+    const qint32 sampleStepX = qMax<qint32>(1, sourceWidth / channelRenderWidth);
+    const qint32 sampleStepY = qMax<qint32>(1, sourceHeight / qMax<qint32>(1, scopeHeight * 2));
+
+    struct WaveformChannel {
+        qint32 startX = 0;
+        qint32 width = 1;
+        QVector<quint16> bins;
+    };
+    std::array<WaveformChannel, 3> waveformChannels;
+    for (qint32 channel = 0; channel < 3; ++channel) {
+        const qint32 channelStart = (channel * scopeWidth) / 3;
+        const qint32 channelEnd = ((channel + 1) * scopeWidth) / 3;
+        WaveformChannel &waveformChannel = waveformChannels[static_cast<size_t>(channel)];
+        waveformChannel.startX = channelStart;
+        waveformChannel.width = qMax<qint32>(1, channelEnd - channelStart);
+        waveformChannel.bins.fill(0, waveformChannel.width * scopeHeight);
+    }
+
+    auto channelValueAt = [](QRgb pixel, qint32 channel) -> qint32 {
+        switch (channel) {
+        case 0: return qRed(pixel);
+        case 1: return qGreen(pixel);
+        default: return qBlue(pixel);
+        }
+    };
+
+    for (qint32 sourceY = sourceYStart; sourceY < sourceYEnd; sourceY += sampleStepY) {
+        const qint32 lineOffset = sourceY * frameWidth;
+        for (qint32 sourceX = sourceXStart; sourceX < sourceXEnd; sourceX += sampleStepX) {
+            const QRgb sourcePixel = rgbData[lineOffset + sourceX];
+            const qint32 sourceOffsetX = sourceX - sourceXStart;
+            for (qint32 channel = 0; channel < 3; ++channel) {
+                WaveformChannel &waveformChannel = waveformChannels[static_cast<size_t>(channel)];
+                const qint32 localX = (waveformChannel.width <= 1)
+                    ? 0
+                    : ((sourceOffsetX * (waveformChannel.width - 1)) / xDenominator);
+                const qint32 value = channelValueAt(sourcePixel, channel);
+                const qint32 mappedY = (scopeHeight - 1) - ((value * (scopeHeight - 1)) / 255);
+                quint16 &binValue = waveformChannel.bins[(mappedY * waveformChannel.width) + localX];
+                if (binValue < std::numeric_limits<quint16>::max()) {
+                    ++binValue;
+                }
+            }
+        }
+    }
+
+    const std::array<QColor, 3> waveformColors = {
+        QColor(255, 96, 96),
+        QColor(96, 255, 128),
+        QColor(128, 176, 255)
+    };
+    for (qint32 channel = 0; channel < 3; ++channel) {
+        const WaveformChannel &waveformChannel = waveformChannels[static_cast<size_t>(channel)];
+        const QColor channelColor = waveformColors[static_cast<size_t>(channel)];
+        for (qint32 yPosition = 0; yPosition < scopeHeight; ++yPosition) {
+            QRgb *scanLine = reinterpret_cast<QRgb *>(scopeImage.scanLine(yPosition));
+            for (qint32 localX = 0; localX < waveformChannel.width; ++localX) {
+                const quint16 density = waveformChannel.bins[(yPosition * waveformChannel.width) + localX];
+                if (density == 0) {
+                    continue;
+                }
+
+                qint32 intensity = static_cast<qint32>(std::sqrt(static_cast<double>(density)) * 48.0);
+                intensity = qBound<qint32>(20, intensity, 255);
+                const qint32 addRed = (channelColor.red() * intensity) / 255;
+                const qint32 addGreen = (channelColor.green() * intensity) / 255;
+                const qint32 addBlue = (channelColor.blue() * intensity) / 255;
+
+                const qint32 targetX = waveformChannel.startX + localX;
+                const QRgb current = scanLine[targetX];
+                scanLine[targetX] = qRgb(
+                    qMin<qint32>(255, qRed(current) + addRed),
+                    qMin<qint32>(255, qGreen(current) + addGreen),
+                    qMin<qint32>(255, qBlue(current) + addBlue));
+            }
+        }
+    }
+
+    QPainter scopePainter(&scopeImage);
+    scopePainter.setRenderHint(QPainter::Antialiasing, false);
+
+    scopePainter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+    scopePainter.setPen(QPen(QColor(150, 150, 150), 1));
+    scopePainter.drawRect(0, 0, scopeWidth - 1, scopeHeight - 1);
+    scopePainter.drawLine(scopeWidth / 3, 0, scopeWidth / 3, scopeHeight - 1);
+    scopePainter.drawLine((scopeWidth * 2) / 3, 0, (scopeWidth * 2) / 3, scopeHeight - 1);
+
+    auto mapCodeValueToY = [scopeHeight](qint32 value) {
+        const qint32 clamped = qBound<qint32>(0, value, 255);
+        return (scopeHeight - 1) - ((clamped * (scopeHeight - 1)) / 255);
+    };
+    const qint32 yStudioBlack = mapCodeValueToY(16);
+    const qint32 yStudioWhite = mapCodeValueToY(235);
+
+    scopePainter.setPen(QPen(QColor(190, 190, 190), 1, Qt::DashLine));
+    scopePainter.drawLine(0, yStudioBlack, scopeWidth - 1, yStudioBlack);
+    scopePainter.drawLine(0, yStudioWhite, scopeWidth - 1, yStudioWhite);
+
+    QFont levelFont = scopePainter.font();
+    levelFont.setPointSize(qMax<qint32>(7, scopeHeight / 42));
+    scopePainter.setFont(levelFont);
+    const QColor levelColor(200, 200, 200);
+    auto drawLevelLabel = [&](qint32 yPosition, const QString &text) {
+        scopePainter.setPen(levelColor);
+        const qint32 baselineY = qBound<qint32>(10, yPosition + 4, scopeHeight - 2);
+        const qint32 labelX = qMax<qint32>(8, scopeWidth - 48);
+        scopePainter.drawText(labelX, baselineY, text);
+    };
+    drawLevelLabel(yStudioWhite, QStringLiteral("235"));
+    drawLevelLabel(yStudioBlack, QStringLiteral("16"));
+
+    scopePainter.setPen(QColor(160, 160, 160));
+    scopePainter.drawText(QRect(8, scopeHeight - 20, qMax<qint32>(20, scopeWidth - 64), 16),
+                          Qt::AlignLeft | Qt::AlignVCenter,
+                          QStringLiteral("Legal range 16-235"));
+
+    QFont labelFont = scopePainter.font();
+    labelFont.setPointSize(qMax<qint32>(8, scopeHeight / 36));
+    labelFont.setBold(true);
+    scopePainter.setFont(labelFont);
+
+    const std::array<QString, 3> labels = { QStringLiteral("R"), QStringLiteral("G"), QStringLiteral("B") };
+    const std::array<QColor, 3> labelColors = {
+        QColor(255, 96, 96),
+        QColor(96, 255, 128),
+        QColor(128, 176, 255)
+    };
+
+    for (qint32 channel = 0; channel < 3; ++channel) {
+        const qint32 channelStart = (channel * scopeWidth) / 3;
+        const qint32 channelEnd = ((channel + 1) * scopeWidth) / 3;
+        scopePainter.setPen(labelColors[static_cast<size_t>(channel)]);
+        scopePainter.drawText(QRect(channelStart + 6, 6, qMax<qint32>(8, channelEnd - channelStart - 12), 28),
+                              Qt::AlignLeft | Qt::AlignTop,
+                              labels[static_cast<size_t>(channel)]);
+    }
+
+    scopePainter.end();
+    return scopeImage.convertToFormat(QImage::Format_RGB32);
 }
 }
 
@@ -325,6 +515,11 @@ bool TbcSource::getSplitViewEnabled() const
     return viewMode == ViewMode::SPLIT_VIEW;
 }
 
+bool TbcSource::getRgbScopeViewEnabled() const
+{
+    return viewMode == ViewMode::RGB_SCOPE_VIEW;
+}
+
 // Method to get the state of the stretch field mode
 bool TbcSource::getStretchField() const
 {
@@ -400,10 +595,10 @@ QImage TbcSource::getImage()
     }
 
     // Get a QImage for the output
-    auto outputImage = generateQImage();
+    auto outputImage = generateQImage(viewMode);
 
     // Highlight dropouts
-    if (dropoutsOn) {
+    if (dropoutsOn && !getRgbScopeViewEnabled()) {
         // Create a painter object
         QPainter imagePainter(&outputImage);
 
@@ -466,6 +661,10 @@ QImage TbcSource::getImage()
                         }
                         break;
                     }
+
+                    case ViewMode::RGB_SCOPE_VIEW: {
+                        break;
+                    }
                 }
             }
         }
@@ -478,6 +677,22 @@ QImage TbcSource::getImage()
     cacheValid = true;
 
     return outputImage;
+}
+
+QImage TbcSource::getRgbScopeImage(const QSize &targetSize)
+{
+    if (metadataOnly) return QImage();
+    if (loadedFrameNumber == -1 && loadedFieldNumber == -1) return QImage();
+
+    const QSize normalizedTargetSize = targetSize.expandedTo(QSize(1, 1));
+    if (rgbScopeCacheValid && rgbScopeCacheSize == normalizedTargetSize) {
+        return rgbScopeCache;
+    }
+
+    rgbScopeCache = generateQImage(ViewMode::RGB_SCOPE_VIEW, normalizedTargetSize);
+    rgbScopeCacheValid = true;
+    rgbScopeCacheSize = normalizedTargetSize;
+    return rgbScopeCache;
 }
 
 // Method to get the number of available frames
@@ -626,6 +841,10 @@ TbcSource::ScanLineData TbcSource::getScanLineData(qint32 scanLine)
             frameLine = scanLine;
             isFirstField = (scanLine % 2) == 0;
             break;
+        }
+
+        case ViewMode::RGB_SCOPE_VIEW: {
+            return ScanLineData();
         }
 
         case ViewMode::SPLIT_VIEW: {
@@ -798,7 +1017,9 @@ TbcSource::FieldTimingData TbcSource::getFieldTimingData()
         return derivedHeight > 0 ? derivedHeight : videoParameters.fieldHeight;
     };
 
-    const bool showBothFields = (viewMode == ViewMode::FRAME_VIEW || viewMode == ViewMode::SPLIT_VIEW);
+    const bool showBothFields = (viewMode == ViewMode::FRAME_VIEW
+                                 || viewMode == ViewMode::SPLIT_VIEW
+                                 || viewMode == ViewMode::RGB_SCOPE_VIEW);
     const bool useFirstField = (loadedFieldNumber % 2) != 0;
     const qint32 selectedInputIndex = useFirstField ? firstInputIndex : secondInputIndex;
 
@@ -1045,6 +1266,10 @@ void TbcSource::resetState()
     loadedFieldNumber = -1;
     inputFieldsValid = false;
     decodedFrameValid = false;
+    rgbScopeCache = QImage();
+    rgbScopeCacheValid = false;
+    rgbScopeCacheSize = QSize();
+    cache = QImage();
     cacheValid = false;
 }
 
@@ -1055,6 +1280,8 @@ void TbcSource::invalidateImageCache()
     // load depends on the decoder parameters
     inputFieldsValid = false;
     decodedFrameValid = false;
+    rgbScopeCacheValid = false;
+    rgbScopeCacheSize = QSize();
     cacheValid = false;
 }
 
@@ -1272,7 +1499,7 @@ void TbcSource::decodeFrame()
 }
 
 // Method to create a QImage for a source video frame
-QImage TbcSource::generateQImage()
+QImage TbcSource::generateQImage(ViewMode renderViewMode, const QSize &targetSize)
 {
     // Get the metadata for the video parameters
     LdDecodeMetaData::VideoParameters videoParameters = ldDecodeMetaData.getVideoParameters();
@@ -1293,7 +1520,7 @@ QImage TbcSource::generateQImage()
 
     if (chromaOn) {
         // Show debug information
-        if (getFieldViewEnabled()) {
+        if (renderViewMode == ViewMode::FIELD_VIEW) {
             tbcDebugStream() << "TbcSource::generateQImage(): Generating a chroma image from field"
                              << loadedFieldNumber << "(" << videoParameters.fieldWidth << "x" << videoParameters.fieldHeight << ")";
         } else {
@@ -1325,7 +1552,7 @@ QImage TbcSource::generateQImage()
         }
     } else {
         // Show debug information
-        if (getFieldViewEnabled()) {
+        if (renderViewMode == ViewMode::FIELD_VIEW) {
             tbcDebugStream() << "TbcSource::generateQImage(): Generating a source image from field"
                              << loadedFieldNumber << "(" << videoParameters.fieldWidth << "x" << videoParameters.fieldHeight << ")";
         } else {
@@ -1358,9 +1585,22 @@ QImage TbcSource::generateQImage()
         }
     }
 
+    if (renderViewMode == ViewMode::RGB_SCOPE_VIEW) {
+        const QImage scopeImage = renderRgbParadeScopeImage(rgbData, frameWidth, frameHeight, videoParameters, targetSize);
+        return scopeImage.isNull() ? outputImage : scopeImage;
+    }
+
     // Copy RGB data to QImage
-    switch (getViewMode()) {
+    switch (renderViewMode) {
         case ViewMode::FRAME_VIEW: {
+            for (auto y = 0; y < inputHeight; y++) {
+                auto *outputLine = reinterpret_cast<QRgb*>(outputImage.scanLine(y + inputOffset));
+                std::copy_n(&rgbData[y * inputWidth], inputWidth, &outputLine[outputOffset]);
+            }
+            break;
+        }
+
+        case ViewMode::RGB_SCOPE_VIEW: {
             for (auto y = 0; y < inputHeight; y++) {
                 auto *outputLine = reinterpret_cast<QRgb*>(outputImage.scanLine(y + inputOffset));
                 std::copy_n(&rgbData[y * inputWidth], inputWidth, &outputLine[outputOffset]);

--- a/src/ld-analyse/tbcsource.h
+++ b/src/ld-analyse/tbcsource.h
@@ -15,6 +15,7 @@
 #include <QObject>
 #include <QImage>
 #include <QPainter>
+#include <QSize>
 #include <QtConcurrent/QtConcurrent>
 #include <QDebug>
 #include <vector>
@@ -103,6 +104,7 @@ public:
         FRAME_VIEW,
         SPLIT_VIEW,
         FIELD_VIEW,
+        RGB_SCOPE_VIEW,
     };
     void setViewMode(ViewMode viewMode);
     void setStretchField(bool _stretch);
@@ -111,6 +113,7 @@ public:
     bool getFrameViewEnabled() const;
     bool getFieldViewEnabled() const;
     bool getSplitViewEnabled() const;
+    bool getRgbScopeViewEnabled() const;
     bool getStretchField() const;
 
     enum SourceMode {
@@ -125,6 +128,7 @@ public:
     void load(qint32 frameNumber, qint32 fieldNumber);
 
     QImage getImage();
+    QImage getRgbScopeImage(const QSize &targetSize = QSize());
     qint32 getNumberOfFrames() const;
     qint32 getNumberOfFields() const;
     bool getIsWidescreen() const;
@@ -242,6 +246,9 @@ private:
     // RGB image data for the loaded frame
     QImage cache;
     bool cacheValid;
+    QImage rgbScopeCache;
+    bool rgbScopeCacheValid;
+    QSize rgbScopeCacheSize;
 
     // Chroma decoder configuration
     PalColour::Configuration palConfiguration;
@@ -259,7 +266,7 @@ private:
     void configureChromaDecoder();
     void loadInputFields();
     void decodeFrame();
-    QImage generateQImage();
+    QImage generateQImage(ViewMode renderViewMode, const QSize &targetSize = QSize());
     QImage generateChromaImage();
     QImage generateMonoImage();
     void generateData();


### PR DESCRIPTION
## Summary

- refactor RGB scope rendering into a dedicated plot region so resizing behaves consistently
- use explicit 0-255 axis mapping and add clear guide lines/labels for 0, 64, 128, 192, 255
- keep 16 and 235 as dashed legal-range reference markers and improve channel label placement

## Verification

- nix develop -c ninja -C /home/harry/tbc-tools/build ld-analyse

## Visual 

<img width="960" height="572" alt="Screenshot from 2026-05-01 21-25-26" src="https://github.com/user-attachments/assets/b496f02f-16c4-4c45-9920-1d89bd0f263d" />

