### PR TITLE
Add EFM handler workflow and GUI updates for AAA/Export

### DIFF
--- a/src/audio-align/audioalignmentutil.cpp
+++ b/src/audio-align/audioalignmentutil.cpp
@@ -385,12 +385,26 @@ QString comparablePathForMatch(const QString &path)
     }
     return info.absoluteFilePath();
 }
+bool containsBasebandKeyword(const QString &audioBaseLower)
+{
+    return audioBaseLower.contains(QStringLiteral("baseband"))
+        || audioBaseLower.contains(QStringLiteral("base_band"))
+        || audioBaseLower.contains(QStringLiteral("base-band"))
+        || audioBaseLower.contains(QStringLiteral("base band"));
+}
+
+bool hasExcludedAutoInputKeyword(const QString &audioFilenameLower)
+{
+    return audioFilenameLower.contains(QStringLiteral("rf"))
+        || audioFilenameLower.contains(QStringLiteral("align"))
+        || audioFilenameLower.contains(QStringLiteral("aligned"));
+}
 
 bool hasPreferredKeyword(const QString &audioBaseLower, AudioPreference preference)
 {
     if (preference == AudioPreference::Linear) {
         return audioBaseLower.contains(QStringLiteral("linear"))
-            || audioBaseLower.contains(QStringLiteral("baseband"));
+            || containsBasebandKeyword(audioBaseLower);
     }
     if (preference == AudioPreference::Hifi) {
         return audioBaseLower.contains(QStringLiteral("hifi"));
@@ -401,7 +415,7 @@ bool hasPreferredKeyword(const QString &audioBaseLower, AudioPreference preferen
 bool isBasebandStereoCh1Ch2Name(const QString &audioBaseLower)
 {
     return audioBaseLower.contains(QStringLiteral("baseband_stereo_ch1_ch2"))
-        || (audioBaseLower.contains(QStringLiteral("baseband"))
+        || (containsBasebandKeyword(audioBaseLower)
             && audioBaseLower.contains(QStringLiteral("stereo"))
             && audioBaseLower.contains(QStringLiteral("ch1"))
             && audioBaseLower.contains(QStringLiteral("ch2")));
@@ -410,7 +424,7 @@ bool isBasebandStereoCh1Ch2Name(const QString &audioBaseLower)
 bool isBasebandStereoCh3Ch4Name(const QString &audioBaseLower)
 {
     return audioBaseLower.contains(QStringLiteral("baseband_stereo_ch3_ch4"))
-        || (audioBaseLower.contains(QStringLiteral("baseband"))
+        || (containsBasebandKeyword(audioBaseLower)
             && audioBaseLower.contains(QStringLiteral("stereo"))
             && audioBaseLower.contains(QStringLiteral("ch3"))
             && audioBaseLower.contains(QStringLiteral("ch4")));
@@ -465,7 +479,7 @@ int audioCandidateScore(const QFileInfo &audioInfo,
         if (audioBaseLower.contains(QStringLiteral("linear"))) {
             bestRootScore += 340;
         }
-        if (audioBaseLower.contains(QStringLiteral("baseband"))) {
+        if (containsBasebandKeyword(audioBaseLower)) {
             bestRootScore += 320;
         }
         if (isBasebandStereoCh3Ch4Name(audioBaseLower)) {
@@ -482,7 +496,7 @@ int audioCandidateScore(const QFileInfo &audioInfo,
             bestRootScore += 300;
         }
         if (audioBaseLower.contains(QStringLiteral("linear"))
-            || audioBaseLower.contains(QStringLiteral("baseband"))) {
+            || containsBasebandKeyword(audioBaseLower)) {
             bestRootScore -= 260;
         }
         break;
@@ -496,7 +510,7 @@ int audioCandidateScore(const QFileInfo &audioInfo,
         if (audioBaseLower.contains(QStringLiteral("linear"))) {
             bestRootScore += 220;
         }
-        if (audioBaseLower.contains(QStringLiteral("baseband"))) {
+        if (containsBasebandKeyword(audioBaseLower)) {
             bestRootScore += 200;
         }
         break;
@@ -551,6 +565,10 @@ QString autoDetectInputAudioFileInternal(const QString &jsonFilename,
         if (!normalizedExclude.isEmpty() && comparablePathForMatch(entryInfo.absoluteFilePath()) == normalizedExclude) {
             continue;
         }
+        const QString audioFilenameLower = entryInfo.fileName().toLower();
+        if (hasExcludedAutoInputKeyword(audioFilenameLower)) {
+            continue;
+        }
 
         const QString audioBaseLower = entryInfo.completeBaseName().toLower();
         if (requirePreferredKeyword && !hasPreferredKeyword(audioBaseLower, preference)) {
@@ -558,8 +576,24 @@ QString autoDetectInputAudioFileInternal(const QString &jsonFilename,
         }
 
         const int candidateScore = audioCandidateScore(entryInfo, rootCandidatesLower, preference);
-        if (candidateScore > bestScore) {
-            bestScore = candidateScore;
+        int effectiveScore = candidateScore;
+        if (effectiveScore <= 0
+            && preference == AudioPreference::Linear
+            && containsBasebandKeyword(audioBaseLower)) {
+            effectiveScore = 260;
+            if (isBasebandStereoCh1Ch2Name(audioBaseLower)) {
+                effectiveScore += 120;
+            }
+            if (isBasebandStereoCh3Ch4Name(audioBaseLower)) {
+                effectiveScore -= 80;
+            }
+            if (suffixLower == QStringLiteral("flac")) {
+                effectiveScore += 30;
+            }
+        }
+
+        if (effectiveScore > bestScore) {
+            bestScore = effectiveScore;
             bestMatch = entryInfo;
         }
     }

--- a/src/efm-decoder/tools/efm-decoder-audio/src/efm_processor.cpp
+++ b/src/efm-decoder/tools/efm-decoder-audio/src/efm_processor.cpp
@@ -29,6 +29,7 @@ EfmProcessor::EfmProcessor() :
     m_showAudio(false),
     m_outputWavMetadata(false),
     m_noAudioConcealment(false),
+    m_zeroPad(false),
     m_noWavHeader(false)
 {}
 
@@ -45,9 +46,15 @@ bool EfmProcessor::process(const QString &inputFilename, const QString &outputFi
 
     // Prepare the output writers
     if (m_noWavHeader) {
-        m_writerRaw.open(outputFilename);
+        if (!m_writerRaw.open(outputFilename)) {
+            m_readerData24Section.close();
+            return false;
+        }
     } else {
-        m_writerWav.open(outputFilename);
+        if (!m_writerWav.open(outputFilename)) {
+            m_readerData24Section.close();
+            return false;
+        }
     }
     
     if (m_outputWavMetadata) {
@@ -57,7 +64,12 @@ bool EfmProcessor::process(const QString &inputFilename, const QString &outputFi
         } else {
             metadataFilename.append(".txt");
         }
-        m_writerWavMetadata.open(metadataFilename, m_noAudioConcealment);
+        if (!m_writerWavMetadata.open(metadataFilename, m_noAudioConcealment)) {
+            if (m_writerWav.isOpen()) m_writerWav.close();
+            if (m_writerRaw.isOpen()) m_writerRaw.close();
+            m_readerData24Section.close();
+            return false;
+        }
     }
 
     // Get the first section
@@ -173,6 +185,9 @@ void EfmProcessor::processAudioPipeline()
     if (m_noAudioConcealment) {
         while (m_data24ToAudio.isReady()) {
             AudioSection audioSection = m_data24ToAudio.popSection();
+            if (m_showAudio) {
+                audioSection.showData();
+            }
             if (m_noWavHeader) {
                 m_writerRaw.write(audioSection);
             } else {
@@ -191,6 +206,9 @@ void EfmProcessor::processAudioPipeline()
 
         while (m_audioCorrection.isReady()) {
             AudioSection audioSection = m_audioCorrection.popSection();
+            if (m_showAudio) {
+                audioSection.showData();
+            }
             if (m_noWavHeader) {
                 m_writerRaw.write(audioSection);
             } else {

--- a/src/efm-decoder/tools/efm-decoder-data/src/decoders/dec_data24torawsector.cpp
+++ b/src/efm-decoder/tools/efm-decoder-data/src/decoders/dec_data24torawsector.cpp
@@ -227,12 +227,20 @@ void Data24ToRawSector::processStateMachine()
 
             // Add the error data
             const QVector<bool>& frameErrorData = data24Section.frame(i).errorData();
-            QByteArray frameErrorBytes = QByteArray(reinterpret_cast<const char*>(frameErrorData.constData()), frameErrorData.size());
+            QByteArray frameErrorBytes;
+            frameErrorBytes.resize(frameErrorData.size());
+            for (int j = 0; j < frameErrorData.size(); ++j) {
+                frameErrorBytes[j] = frameErrorData.at(j) ? 1 : 0;
+            }
             m_sectorErrorData.append(frameErrorBytes);
 
             // Add the padding data
             const QVector<bool>& framePaddedData = data24Section.frame(i).paddedData();
-            QByteArray framePaddedBytes = QByteArray(reinterpret_cast<const char*>(framePaddedData.constData()), framePaddedData.size());
+            QByteArray framePaddedBytes;
+            framePaddedBytes.resize(framePaddedData.size());
+            for (int j = 0; j < framePaddedData.size(); ++j) {
+                framePaddedBytes[j] = framePaddedData.at(j) ? 1 : 0;
+            }
             m_sectorPaddedData.append(framePaddedBytes);
         }
 
@@ -271,9 +279,16 @@ Data24ToRawSector::State Data24ToRawSector::waitingForSync()
         //if (m_showDebug) tbcDebugStream() << "Data24ToRawSector::waitingForSync(): No sync pattern found in sectorData, discarding" << m_sectorData.size() - 11 << "bytes";
 
         // Clear the sector data buffer (except the last 11 bytes)
-        m_discardedBytes += m_sectorData.size() - 11;
+        const int discardCount = qMax(0, m_sectorData.size() - 11);
+        m_discardedBytes += discardCount;
+        for (int i = 0; i < discardCount && i < m_sectorPaddedData.size(); ++i) {
+            if (static_cast<quint8>(m_sectorPaddedData[i]) == 1) {
+                ++m_discardedPaddingBytes;
+            }
+        }
         m_sectorData = m_sectorData.right(11);
         m_sectorErrorData = m_sectorErrorData.right(11);
+        m_sectorPaddedData = m_sectorPaddedData.right(11);
 
         // Get more data and try again
         nextState = WaitingForSync;
@@ -282,6 +297,11 @@ Data24ToRawSector::State Data24ToRawSector::waitingForSync()
 
         // Discard any data before the sync pattern
         m_discardedBytes += syncPatternPosition;
+        for (int i = 0; i < syncPatternPosition && i < m_sectorPaddedData.size(); ++i) {
+            if (static_cast<quint8>(m_sectorPaddedData[i]) == 1) {
+                ++m_discardedPaddingBytes;
+            }
+        }
         m_sectorData = m_sectorData.right(m_sectorData.size() - syncPatternPosition);
         m_sectorErrorData = m_sectorErrorData.right(m_sectorErrorData.size() - syncPatternPosition);
         m_sectorPaddedData = m_sectorPaddedData.right(m_sectorPaddedData.size() - syncPatternPosition);
@@ -303,6 +323,15 @@ Data24ToRawSector::State Data24ToRawSector::waitingForSync()
 
         if (errorByteCount > 1000 || paddingByteCount > 1000) {
             if (m_showDebug) tbcDebugStream() << "Data24ToRawSector::waitingForSync(): Discarding sync as false positive due to" << errorByteCount << "error bytes and" << paddingByteCount << "padding bytes";
+            if (!m_sectorData.isEmpty()) {
+                m_discardedBytes++;
+                if (!m_sectorPaddedData.isEmpty() && static_cast<quint8>(m_sectorPaddedData.at(0)) == 1) {
+                    ++m_discardedPaddingBytes;
+                }
+                m_sectorData.remove(0, 1);
+                m_sectorErrorData.remove(0, 1);
+                m_sectorPaddedData.remove(0, 1);
+            }
             nextState = WaitingForSync;
         } else {
             if (m_showDebug) tbcDebugStream() << "Data24ToRawSector::waitingForSync(): Valid sector sync found with" << errorByteCount << "error bytes and" << paddingByteCount << "padding bytes";
@@ -380,7 +409,7 @@ Data24ToRawSector::State Data24ToRawSector::inSync()
         // Unscramble the sector (bytes 12 to 2351)
         QByteArray rawDataOut = m_sectorData.left(2352);
         QByteArray rawErrorDataOut = m_sectorErrorData.left(2352);
-        QByteArray rawPaddedDataOut = m_sectorErrorData.left(2352);
+        QByteArray rawPaddedDataOut = m_sectorPaddedData.left(2352);
 
         for (qint32 i = 0; i < 2352; i++) {
             if (i < 12) {
@@ -406,7 +435,7 @@ Data24ToRawSector::State Data24ToRawSector::inSync()
         // Remove 2352 bytes of processed data from the buffers
         m_sectorData = m_sectorData.right(m_sectorData.size() - 2352);
         m_sectorErrorData = m_sectorErrorData.right(m_sectorErrorData.size() - 2352);
-        m_sectorPaddedData = m_sectorErrorData.right(m_sectorPaddedData.size() - 2352);
+        m_sectorPaddedData = m_sectorPaddedData.right(m_sectorPaddedData.size() - 2352);
     }
 
     return nextState;

--- a/src/efm-decoder/tools/efm-decoder-data/src/decoders/dec_sectorcorrection.cpp
+++ b/src/efm-decoder/tools/efm-decoder-data/src/decoders/dec_sectorcorrection.cpp
@@ -59,7 +59,7 @@ void SectorCorrection::processQueue()
             // This is the first sector - we have to fill the missing leading sectors
             // if the address isn't 0
 
-            if (sector.address().frameNumber() != 0) {
+            if (sector.address().address() != 0) {
                 // Fill the missing leading sectors from address 0 to the first decoded sector address
                 if (m_showDebug) {
                     tbcDebugStream().nospace().noquote() << "SectorCorrection::processQueue(): First received frame address is "

--- a/src/efm-decoder/tools/efm-decoder-data/src/efm_processor.cpp
+++ b/src/efm-decoder/tools/efm-decoder-data/src/efm_processor.cpp
@@ -26,6 +26,7 @@
 #include "tbc/logging.h"
 
 EfmProcessor::EfmProcessor() : 
+    m_showRawSector(false),
     m_outputDataMetadata(false)
 {}
 
@@ -41,7 +42,10 @@ bool EfmProcessor::process(const QString &inputFilename, const QString &outputFi
     }
 
     // Prepare the output file writers
-    m_writerSector.open(outputFilename);
+    if (!m_writerSector.open(outputFilename)) {
+        m_readerData24Section.close();
+        return false;
+    }
     if (m_outputDataMetadata) {
         QString metadataFilename = outputFilename;
         if (metadataFilename.endsWith(".dat")) {
@@ -49,7 +53,11 @@ bool EfmProcessor::process(const QString &inputFilename, const QString &outputFi
         } else {
             metadataFilename.append(".bsm");
         }
-        m_writerSectorMetadata.open(metadataFilename);
+        if (!m_writerSectorMetadata.open(metadataFilename)) {
+            if (m_writerSector.isOpen()) m_writerSector.close();
+            m_readerData24Section.close();
+            return false;
+        }
     }
 
     // Process the Data24 Section data
@@ -66,6 +74,13 @@ bool EfmProcessor::process(const QString &inputFilename, const QString &outputFi
             if (!m_readerData24Section.hasMoreData() && !section.isComplete()) {
                 break; // End of stream
             }
+            if (!section.isComplete()) {
+                qCritical() << "EfmProcessor::process(): Incomplete Data24 section encountered while streaming";
+                m_readerData24Section.close();
+                if (m_writerSector.isOpen()) m_writerSector.close();
+                if (m_writerSectorMetadata.isOpen()) m_writerSectorMetadata.close();
+                return false;
+            }
             
             m_data24ToRawSector.pushSection(section);
             m_dataPipelineStats.data24ToRawSectorTime += dataPipelineTimer.nsecsElapsed();
@@ -81,7 +96,15 @@ bool EfmProcessor::process(const QString &inputFilename, const QString &outputFi
         // File mode: process with known size
         for (index = 0; index < m_readerData24Section.size(); ++index) {
             dataPipelineTimer.restart();
-            m_data24ToRawSector.pushSection(m_readerData24Section.read());
+            const Data24Section section = m_readerData24Section.read();
+            if (!section.isComplete()) {
+                qCritical() << "EfmProcessor::process(): Incomplete Data24 section encountered at index" << index;
+                m_readerData24Section.close();
+                if (m_writerSector.isOpen()) m_writerSector.close();
+                if (m_writerSectorMetadata.isOpen()) m_writerSectorMetadata.close();
+                return false;
+            }
+            m_data24ToRawSector.pushSection(section);
             m_dataPipelineStats.data24ToRawSectorTime += dataPipelineTimer.nsecsElapsed();
             processDataPipeline();
 

--- a/src/efm-decoder/tools/efm-decoder-f2/src/decoders/dec_f2sectioncorrection.cpp
+++ b/src/efm-decoder/tools/efm-decoder-f2/src/decoders/dec_f2sectioncorrection.cpp
@@ -464,9 +464,12 @@ void F2SectionCorrection::processInternalBuffer()
 
             // Is the gap length below the allowed maximum?
             if (gapLength > m_maximumGapSize) {
-                // The gap is too large to correct
-                qFatal("F2SectionCorrection::correctInternalBuffer(): Exiting due to gap too "
-                       "large in internal buffer.");
+                qWarning().nospace().noquote()
+                        << "F2SectionCorrection::correctInternalBuffer(): Gap length "
+                        << gapLength
+                        << " exceeds configured maximum "
+                        << m_maximumGapSize
+                        << " - attempting best-effort correction.";
             }
 
             // Can we correct the error?
@@ -500,17 +503,16 @@ void F2SectionCorrection::processInternalBuffer()
                         // calculating the current section time from it.  If the time is positive
                         // the error section is in the same track as error_end, otherwise it is in
                         // the same track as error_start
-                        SectionTime currentTime =
-                                m_internalBuffer[errorEnd].metadata.sectionTime()
+                        const qint32 currentTimeFrames =
+                                m_internalBuffer[errorEnd].metadata.sectionTime().frames()
                                 - (errorEnd - i);
 
                         // Now we can set the track number and correct the section time
-                        if (currentTime.frames() >= 0) {
+                        if (currentTimeFrames >= 0) {
                             m_internalBuffer[i].metadata.setTrackNumber(
                                     m_internalBuffer[errorEnd].metadata.trackNumber());
                             m_internalBuffer[i].metadata.setSectionTime(
-                                    m_internalBuffer[errorEnd].metadata.sectionTime()
-                                    - (errorEnd - i));
+                                    SectionTime(currentTimeFrames));
                         } else {
                             m_internalBuffer[i].metadata.setTrackNumber(
                                     m_internalBuffer[errorStart].metadata.trackNumber());
@@ -519,11 +521,9 @@ void F2SectionCorrection::processInternalBuffer()
                                     + (i - errorStart));
                         }
 
-                        // Adding a qFatal here as this functionality is untested
-                        // (I haven't found any examples of this in the test data)
-                        qFatal("F2SectionCorrection::correctInternalBuffer(): Exiting due to "
-                               "track change in internal buffer - untested functionality - please "
-                               "confirm!");
+                        qWarning("F2SectionCorrection::correctInternalBuffer(): Track change in "
+                                 "internal buffer detected - applying best-effort metadata "
+                                 "correction.");
                     } else {
                         // The track number is the same, so we can correct the track number by just
                         // copying it
@@ -556,9 +556,53 @@ void F2SectionCorrection::processInternalBuffer()
                                 << originalMetadata.absoluteSectionTime().toString();
                 }
             } else {
-                // We cannot correct the error
-                qFatal("F2SectionCorrection::correctInternalBuffer(): Exiting due to "
-                       "uncorrectable error in internal buffer.");
+                // We cannot perfectly correct the error, so fall back to a best-effort
+                // monotonic metadata reconstruction and keep processing.
+                qWarning().nospace().noquote()
+                        << "F2SectionCorrection::correctInternalBuffer(): Uncorrectable "
+                           "metadata gap detected between "
+                        << m_internalBuffer[errorStart].metadata.absoluteSectionTime().toString()
+                        << " and "
+                        << m_internalBuffer[errorEnd].metadata.absoluteSectionTime().toString()
+                        << " (gap length "
+                        << gapLength
+                        << ", time difference "
+                        << timeDifference
+                        << ") - applying fallback metadata interpolation.";
+
+                for (int i = errorStart + 1; i < errorEnd; ++i) {
+                    SectionMetadata originalMetadata = m_internalBuffer[i].metadata;
+
+                    // Start with the previous known-good section metadata as a safe baseline.
+                    m_internalBuffer[i].metadata = m_internalBuffer[errorStart].metadata;
+
+                    // Force monotonic absolute time progression.
+                    SectionTime expectedTime =
+                            m_internalBuffer[errorStart].metadata.absoluteSectionTime()
+                            + (i - errorStart);
+                    m_internalBuffer[i].metadata.setAbsoluteSectionTime(expectedTime);
+
+                    // Preserve track continuity from the start section.
+                    m_internalBuffer[i].metadata.setTrackNumber(
+                            m_internalBuffer[errorStart].metadata.trackNumber());
+                    m_internalBuffer[i].metadata.setSectionTime(
+                            m_internalBuffer[errorStart].metadata.sectionTime()
+                            + (i - errorStart));
+
+                    m_internalBuffer[i].metadata.setValid(true);
+                    m_uncorrectableSections++;
+
+                    if (m_showDebug) {
+                        tbcDebugStream().noquote().nospace()
+                                << "F2SectionCorrection::correctInternalBuffer(): Fallback "
+                                   "corrected section "
+                                << i
+                                << " to absolute time "
+                                << m_internalBuffer[i].metadata.absoluteSectionTime().toString()
+                                << " from original metadata absolute time "
+                                << originalMetadata.absoluteSectionTime().toString();
+                    }
+                }
             }
         }
     }

--- a/src/ld-analyse/CMakeLists.txt
+++ b/src/ld-analyse/CMakeLists.txt
@@ -65,6 +65,16 @@ target_link_libraries(ld-analyse PRIVATE
     Qt::Core Qt::Gui Qt::Widgets Qt::Svg
     lddecode-library lddecode-chroma
 )
+add_executable(tbc-efm-handler
+    efmhandler-main.cpp
+    efmhandlerdialog.cpp
+    efmhandlerdialog.h
+)
+
+target_link_libraries(tbc-efm-handler PRIVATE
+    Qt::Core Qt::Gui Qt::Widgets
+    lddecode-library
+)
 
 set(_audio_align_vendor_dir "${CMAKE_SOURCE_DIR}/src/audio-align/vendor/vhs_decode_auto_audio_align")
 target_compile_definitions(ld-analyse PRIVATE
@@ -93,6 +103,7 @@ endif()
 
 if(UNIX)
 	install(TARGETS ld-analyse BUNDLE DESTINATION bin)
+	install(TARGETS tbc-efm-handler)
 	
 	# Install desktop integration files directly to XDG standard locations
 	# This avoids hanging issues with xdg-* commands run via sudo
@@ -138,4 +149,5 @@ else()
 			TARGETS ld-analyse
 			BUNDLE DESTINATION bin
 	)
+	install(TARGETS tbc-efm-handler)
 endif()

--- a/src/ld-analyse/CMakeLists.txt
+++ b/src/ld-analyse/CMakeLists.txt
@@ -7,6 +7,7 @@ set(ld-analyse_SOURCES
     ../audio-align/audioalignmentdialog.cpp ../audio-align/audioalignmentdialog.h ../audio-align/audioalignmentdialog.ui
     ../audio-align/audioalignmentutil.cpp ../audio-align/audioalignmentutil.h
     closedcaptionsdialog.cpp closedcaptionsdialog.ui
+    efmhandlerdialog.cpp efmhandlerdialog.h
     exportdialog.cpp exportdialog.ui
     metadataconversiondialog.cpp metadataconversiondialog.ui
     metadatastatusdialog.cpp metadatastatusdialog.ui

--- a/src/ld-analyse/efmhandler-main.cpp
+++ b/src/ld-analyse/efmhandler-main.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
- * main.cpp
- * tbc-audio-align - Audio alignment tool for ld-decode
+ * efmhandler-main.cpp
+ * tbc-efm-handler - Dedicated EFM/AC3 handling workflow GUI
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  * SPDX-FileCopyrightText: 2026 Simon Inns
@@ -13,7 +13,9 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QCoreApplication>
+#include <QFileInfo>
 #include <QPalette>
+#include <QStringList>
 #include <QStyleFactory>
 #if defined(Q_OS_WIN)
 #include <QSettings>
@@ -23,7 +25,7 @@
 #include <QProcess>
 #endif
 
-#include "audioalignmentdialog.h"
+#include "efmhandlerdialog.h"
 #include "tbc/logging.h"
 namespace {
 // Cross-platform function to detect if system is in dark mode
@@ -115,18 +117,17 @@ int main(int argc, char *argv[])
         app.setStyle(QStringLiteral("Fusion"));
     }
 
-    // Set application name and version
-    QCoreApplication::setApplicationName("tbc-audio-align");
-    QCoreApplication::setApplicationVersion(QString("ld-decode-tools - Branch: %1 / Commit: %2").arg(APP_BRANCH, APP_COMMIT));
-    QCoreApplication::setOrganizationDomain("domesday86.com");
+    QCoreApplication::setApplicationName("tbc-efm-handler");
+    QCoreApplication::setApplicationVersion(
+        QString("ld-decode-tools - Branch: %1 / Commit: %2").arg(APP_BRANCH, APP_COMMIT));
+    QCoreApplication::setOrganizationDomain("github.com");
 
-    // Set up the command line parser
     QCommandLineParser parser;
     parser.setApplicationDescription(
-                "tbc-audio-align - Audio alignment tool for ld-decode\n"
-                "\n"
-                "(c)2026 Simon Inns\n"
-                "GPLv3 Open-Source - github: https://github.com/happycube/ld-decode");
+        "tbc-efm-handler - Dedicated EFM/AC3 handling workflow GUI\n"
+        "\n"
+        "(c)2026 Simon Inns\n"
+        "GPLv3 Open-Source - github: https://github.com/happycube/ld-decode");
     parser.addHelpOption();
     parser.addVersionOption();
 
@@ -134,36 +135,34 @@ int main(int argc, char *argv[])
     addStandardDebugOptions(parser);
 
     QCommandLineOption sourceDirectoryOption(QStringList() << "source-dir",
-                                             QCoreApplication::translate("main", "Initial source directory used by browse dialogs"),
+                                             QCoreApplication::translate(
+                                                 "main", "Initial source directory used by browse dialogs"),
                                              QCoreApplication::translate("main", "path"));
     parser.addOption(sourceDirectoryOption);
 
-    QCommandLineOption jsonOption(QStringList() << "json",
-                                  QCoreApplication::translate("main", "Prefill metadata JSON input"),
-                                  QCoreApplication::translate("main", "filename"));
-    parser.addOption(jsonOption);
+    QCommandLineOption efmInputOption(QStringList() << "efm-input",
+                                      QCoreApplication::translate(
+                                          "main", "Prefill EFM input file (can be passed multiple times)"),
+                                      QCoreApplication::translate("main", "filename"));
+    parser.addOption(efmInputOption);
 
-    QCommandLineOption inputFileOption(QStringList() << "input-file",
-                                       QCoreApplication::translate("main", "Prefill input audio stream"),
-                                       QCoreApplication::translate("main", "filename"));
-    parser.addOption(inputFileOption);
+    QCommandLineOption ac3InputOption(QStringList() << "ac3-input",
+                                      QCoreApplication::translate("main", "Prefill AC3 symbols input file"),
+                                      QCoreApplication::translate("main", "filename"));
+    parser.addOption(ac3InputOption);
 
-    QCommandLineOption outputFileOption(QStringList() << "output-file",
-                                        QCoreApplication::translate("main", "Prefill output audio stream"),
-                                        QCoreApplication::translate("main", "filename"));
-    parser.addOption(outputFileOption);
-
-    QCommandLineOption rfVideoSampleRateOption(QStringList() << "rf-video-sample-rate-hz",
-                                               QCoreApplication::translate("main", "Prefill RF video sample rate in Hz"),
-                                               QCoreApplication::translate("main", "hz"));
-    parser.addOption(rfVideoSampleRateOption);
-
-    QCommandLineOption exportTrackFileOption(QStringList() << "export-track-file",
-                                             QCoreApplication::translate("main", "Write aligned track details for ld-analyse export auto-load"),
-                                             QCoreApplication::translate("main", "filename"));
-    parser.addOption(exportTrackFileOption);
+    QCommandLineOption outputBaseOption(QStringList() << "output-base",
+                                        QCoreApplication::translate("main", "Prefill EFM output base path"),
+                                        QCoreApplication::translate("main", "path"));
+    parser.addOption(outputBaseOption);
     parser.addOption(QCommandLineOption("force-dark-theme",
                                         QCoreApplication::translate("main", "Force dark theme regardless of system settings")));
+
+    parser.addPositionalArgument(
+        "input",
+        QCoreApplication::translate("main",
+                                    "Optional input file(s) to preload (.efm => EFM input, others => AC3 input)"),
+        "[input ...]");
 
     parser.process(app);
     processStandardDebugOptions(parser);
@@ -174,28 +173,32 @@ int main(int argc, char *argv[])
         applyDarkTheme(app);
     }
 
-    AudioAlignmentDialog dialog;
+    EfmHandlerDialog dialog;
+
     if (parser.isSet(sourceDirectoryOption)) {
         dialog.setSourceDirectory(parser.value(sourceDirectoryOption));
     }
-    if (parser.isSet(jsonOption)) {
-        dialog.setDefaultJson(parser.value(jsonOption));
-    }
-    if (parser.isSet(inputFileOption)) {
-        dialog.setDefaultInputFile(parser.value(inputFileOption));
-    }
-    if (parser.isSet(outputFileOption)) {
-        dialog.setDefaultOutputFile(parser.value(outputFileOption));
-    }
-    if (parser.isSet(exportTrackFileOption)) {
-        dialog.setExportTrackOutputFile(parser.value(exportTrackFileOption));
+
+    const QStringList efmInputs = parser.values(efmInputOption);
+    for (const QString &efmInput : efmInputs) {
+        dialog.setDefaultEfmInput(efmInput);
     }
 
-    bool ok = false;
-    if (parser.isSet(rfVideoSampleRateOption)) {
-        const quint32 rfSampleRate = parser.value(rfVideoSampleRateOption).toUInt(&ok);
-        if (ok && rfSampleRate > 0) {
-            dialog.setDefaultRfVideoSampleRate(rfSampleRate);
+    if (parser.isSet(ac3InputOption)) {
+        dialog.setDefaultAc3Input(parser.value(ac3InputOption));
+    }
+
+    if (parser.isSet(outputBaseOption)) {
+        dialog.setSuggestedOutputBase(parser.value(outputBaseOption));
+    }
+
+    const QStringList positionalInputs = parser.positionalArguments();
+    for (const QString &positionalInput : positionalInputs) {
+        const QString suffix = QFileInfo(positionalInput).suffix().trimmed().toLower();
+        if (suffix == QStringLiteral("efm")) {
+            dialog.setDefaultEfmInput(positionalInput);
+        } else {
+            dialog.setDefaultAc3Input(positionalInput);
         }
     }
 

--- a/src/ld-analyse/efmhandlerdialog.cpp
+++ b/src/ld-analyse/efmhandlerdialog.cpp
@@ -128,6 +128,47 @@ void EfmHandlerDialog::setDefaultEfmInput(const QString &efmFilename)
     }
     updateControlStates();
 }
+void EfmHandlerDialog::setDefaultAc3Input(const QString &ac3Filename)
+{
+    if (runInProgress) {
+        return;
+    }
+
+    const QString normalizedInput = normalizePath(ac3Filename);
+    if (normalizedInput.isEmpty()) {
+        return;
+    }
+
+    const QFileInfo inputInfo(normalizedInput);
+    const QString absoluteInput = inputInfo.absoluteFilePath();
+    if (!inputInfo.exists() || !inputInfo.isFile()) {
+        return;
+    }
+
+    const QString currentAc3Input = normalizePath(ac3InputLineEdit ? ac3InputLineEdit->text() : QString());
+    if (!currentAc3Input.isEmpty()) {
+        const QFileInfo currentInfo(currentAc3Input);
+        if (currentInfo.absoluteFilePath().compare(absoluteInput, Qt::CaseInsensitive) == 0) {
+            return;
+        }
+    }
+
+    if (ac3InputLineEdit && ac3InputLineEdit->text().trimmed().isEmpty()) {
+        ac3InputLineEdit->setText(absoluteInput);
+        if (decodeAc3CheckBox && !decodeAc3CheckBox->isChecked()) {
+            decodeAc3CheckBox->setChecked(true);
+        }
+        sourceDirectory = inputInfo.absolutePath();
+
+        if (ac3OutputLineEdit
+            && (!userEditedAc3Output || ac3OutputLineEdit->text().trimmed().isEmpty())) {
+            ac3OutputLineEdit->setText(
+                QDir(inputInfo.absolutePath()).filePath(inputInfo.completeBaseName() + QStringLiteral(".ac3")));
+            userEditedAc3Output = false;
+        }
+        updateControlStates();
+    }
+}
 
 void EfmHandlerDialog::setSuggestedOutputBase(const QString &outputBasePath)
 {

--- a/src/ld-analyse/efmhandlerdialog.cpp
+++ b/src/ld-analyse/efmhandlerdialog.cpp
@@ -1,0 +1,1209 @@
+/******************************************************************************
+ * efmhandlerdialog.cpp
+ * ld-analyse - Dedicated EFM/AC3 handling workflow GUI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ *
+ * This file is part of ld-decode-tools.
+ ******************************************************************************/
+
+#include "efmhandlerdialog.h"
+
+#include <QApplication>
+#include <QAbstractItemView>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QElapsedTimer>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QFont>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QProcess>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QScrollBar>
+#include <QSizePolicy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QVBoxLayout>
+
+namespace {
+void appendUniqueCaseInsensitive(QStringList *list, const QString &value)
+{
+    if (!list || value.trimmed().isEmpty()) {
+        return;
+    }
+    for (const QString &existing : *list) {
+        if (existing.compare(value, Qt::CaseInsensitive) == 0) {
+            return;
+        }
+    }
+    list->append(value);
+}
+
+bool isRunnableFile(const QString &candidatePath)
+{
+    const QFileInfo candidateInfo(candidatePath);
+#if defined(Q_OS_WIN)
+    return candidateInfo.exists() && candidateInfo.isFile();
+#else
+    return candidateInfo.exists() && candidateInfo.isFile() && candidateInfo.isExecutable();
+#endif
+}
+
+QString quoteForShell(const QString &arg)
+{
+    if (arg.isEmpty()) {
+        return QStringLiteral("''");
+    }
+    QString escaped = arg;
+    escaped.replace(QStringLiteral("'"), QStringLiteral("'\"'\"'"));
+    return QStringLiteral("'%1'").arg(escaped);
+}
+
+QString chooseStartDirectory(const QString &preferredDirectory)
+{
+    const QString normalizedPreferred = QDir::cleanPath(preferredDirectory.trimmed());
+    if (!normalizedPreferred.isEmpty() && QFileInfo::exists(normalizedPreferred)) {
+        return normalizedPreferred;
+    }
+    return QDir::homePath();
+}
+} // namespace
+
+EfmHandlerDialog::EfmHandlerDialog(QWidget *parent) :
+    QDialog(parent)
+{
+    buildUi();
+    setBusy(false);
+    appendStatus(tr("Ready."));
+}
+
+void EfmHandlerDialog::setSourceDirectory(const QString &directory)
+{
+    const QString normalizedDirectory = QDir::cleanPath(directory.trimmed());
+    if (normalizedDirectory.isEmpty()) {
+        return;
+    }
+    sourceDirectory = normalizedDirectory;
+}
+
+void EfmHandlerDialog::setDefaultEfmInput(const QString &efmFilename)
+{
+    const QString normalizedInput = normalizePath(efmFilename);
+    if (normalizedInput.isEmpty()) {
+        return;
+    }
+    const QFileInfo inputInfo(normalizedInput);
+    const QString absoluteInput = inputInfo.absoluteFilePath();
+    if (!inputInfo.exists() || !inputInfo.isFile()) {
+        return;
+    }
+
+    for (int index = 0; index < efmInputListWidget->count(); ++index) {
+        QListWidgetItem *item = efmInputListWidget->item(index);
+        if (item && item->text().compare(absoluteInput, Qt::CaseInsensitive) == 0) {
+            return;
+        }
+    }
+
+    efmInputListWidget->addItem(absoluteInput);
+    sourceDirectory = inputInfo.absolutePath();
+    if (!userEditedOutputBase || outputBaseLineEdit->text().trimmed().isEmpty()) {
+        outputBaseLineEdit->setText(defaultOutputBaseFromInputs());
+        userEditedOutputBase = false;
+        refreshDerivedOutputPaths(false);
+    }
+    updateControlStates();
+}
+
+void EfmHandlerDialog::setSuggestedOutputBase(const QString &outputBasePath)
+{
+    if (runInProgress) {
+        return;
+    }
+
+    const QString normalizedBasePath = normalizePath(outputBasePath);
+    if (normalizedBasePath.isEmpty()) {
+        return;
+    }
+
+    if (outputBaseLineEdit
+        && (!userEditedOutputBase || outputBaseLineEdit->text().trimmed().isEmpty())) {
+        outputBaseLineEdit->setText(normalizedBasePath);
+        userEditedOutputBase = false;
+        refreshDerivedOutputPaths(false);
+    }
+}
+
+void EfmHandlerDialog::buildUi()
+{
+    setWindowTitle(tr("EFM-Handler"));
+    resize(860, 730);
+    setMinimumSize(860, 690);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(8, 8, 8, 8);
+    mainLayout->setSpacing(8);
+    mainLayout->setSizeConstraint(QLayout::SetMinimumSize);
+
+    efmGroupBox = new QGroupBox(tr("EFM pipeline"), this);
+    QGridLayout *efmLayout = new QGridLayout(efmGroupBox);
+    efmLayout->setHorizontalSpacing(6);
+    efmLayout->setVerticalSpacing(6);
+    efmLayout->setColumnStretch(1, 1);
+    efmLayout->setColumnStretch(2, 1);
+
+
+    noTimecodesCheckBox = new QCheckBox(tr("Input EFM has no timecodes (--no-timecodes)"), efmGroupBox);
+    noTimecodesCheckBox->setToolTip(tr("Used when running efm-decoder-f2 (--no-timecodes)."));
+    efmLayout->addWidget(noTimecodesCheckBox, 0, 0, 1, 4);
+
+    stackF2CheckBox = new QCheckBox(tr("Stack multiple sources before D24"), efmGroupBox);
+    stackF2CheckBox->setChecked(true);
+    stackF2CheckBox->setToolTip(tr("Only applies when two or more EFM inputs are present."));
+    efmLayout->addWidget(stackF2CheckBox, 1, 0, 1, 4);
+
+    QLabel *outputBaseLabel = new QLabel(tr("Output base"), efmGroupBox);
+    efmLayout->addWidget(outputBaseLabel, 2, 0, 1, 1);
+    outputBaseLineEdit = new QLineEdit(efmGroupBox);
+    outputBaseLineEdit->setPlaceholderText(tr("/path/to/output_base (used for .d24 default outputs)"));
+    efmLayout->addWidget(outputBaseLineEdit, 2, 1, 1, 2);
+    outputBaseBrowseButton = new QPushButton(tr("Browse..."), efmGroupBox);
+    efmLayout->addWidget(outputBaseBrowseButton, 2, 3, 1, 1);
+
+    extractAudioCheckBox = new QCheckBox(tr("Extract audio"), efmGroupBox);
+    extractAudioCheckBox->setChecked(true);
+    efmLayout->addWidget(extractAudioCheckBox, 3, 0, 1, 1);
+    audioOutputLineEdit = new QLineEdit(efmGroupBox);
+    audioOutputLineEdit->setPlaceholderText(tr("Decoded audio output (.wav)"));
+    efmLayout->addWidget(audioOutputLineEdit, 3, 1, 1, 2);
+    audioOutputBrowseButton = new QPushButton(tr("Browse..."), efmGroupBox);
+    efmLayout->addWidget(audioOutputBrowseButton, 3, 3, 1, 1);
+
+    extractDataCheckBox = new QCheckBox(tr("Extract data"), efmGroupBox);
+    extractDataCheckBox->setChecked(true);
+    efmLayout->addWidget(extractDataCheckBox, 4, 0, 1, 1);
+    dataOutputLineEdit = new QLineEdit(efmGroupBox);
+    dataOutputLineEdit->setPlaceholderText(tr("Decoded data output (.bin/.dat)"));
+    efmLayout->addWidget(dataOutputLineEdit, 4, 1, 1, 2);
+    dataOutputBrowseButton = new QPushButton(tr("Browse..."), efmGroupBox);
+    efmLayout->addWidget(dataOutputBrowseButton, 4, 3, 1, 1);
+
+    outputBadSectorMapCheckBox = new QCheckBox(tr("Write bad-sector map metadata (.bsm)"), efmGroupBox);
+    outputBadSectorMapCheckBox->setChecked(true);
+    efmLayout->addWidget(outputBadSectorMapCheckBox, 5, 1, 1, 3);
+
+    QGroupBox *efmInputsSubBox = new QGroupBox(tr("EFM inputs"), efmGroupBox);
+    efmInputsSubBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    efmInputsSubBox->setMinimumHeight(120);
+    QGridLayout *efmInputsLayout = new QGridLayout(efmInputsSubBox);
+    efmInputsLayout->setHorizontalSpacing(6);
+    efmInputsLayout->setVerticalSpacing(6);
+    efmInputsLayout->setColumnStretch(0, 1);
+
+    efmInputListWidget = new QListWidget(efmInputsSubBox);
+    efmInputListWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    efmInputListWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    efmInputListWidget->setMinimumWidth(0);
+    efmInputListWidget->setMinimumHeight(84);
+    efmInputsLayout->addWidget(efmInputListWidget, 0, 0, 1, 1);
+
+    QVBoxLayout *efmInputButtonsLayout = new QVBoxLayout();
+    efmInputButtonsLayout->setContentsMargins(0, 0, 0, 0);
+    efmInputButtonsLayout->setSpacing(6);
+    efmInputButtonsLayout->setAlignment(Qt::AlignTop);
+    addEfmInputButton = new QPushButton(tr("Add..."), efmInputsSubBox);
+    removeEfmInputButton = new QPushButton(tr("Remove"), efmInputsSubBox);
+    clearEfmInputsButton = new QPushButton(tr("Clear"), efmInputsSubBox);
+    efmInputButtonsLayout->addWidget(addEfmInputButton);
+    efmInputButtonsLayout->addWidget(removeEfmInputButton);
+    efmInputButtonsLayout->addWidget(clearEfmInputsButton);
+    efmInputsLayout->addLayout(efmInputButtonsLayout, 0, 1, 1, 1);
+
+    efmLayout->addWidget(efmInputsSubBox, 6, 0, 1, 4);
+
+    const QSizePolicy browseButtonPolicy = outputBaseBrowseButton->sizePolicy();
+    const int standardButtonWidth = qMax(outputBaseBrowseButton->sizeHint().width(),
+                                         qMax(audioOutputBrowseButton->sizeHint().width(),
+                                              dataOutputBrowseButton->sizeHint().width()));
+    const int standardButtonHeight = qMax(outputBaseBrowseButton->sizeHint().height(),
+                                          qMax(audioOutputBrowseButton->sizeHint().height(),
+                                               dataOutputBrowseButton->sizeHint().height()));
+    const auto normalizeSidebarButton = [browseButtonPolicy, standardButtonWidth, standardButtonHeight](QPushButton *button) {
+        if (!button) {
+            return;
+        }
+        button->setSizePolicy(browseButtonPolicy);
+        button->setFixedSize(standardButtonWidth, standardButtonHeight);
+    };
+    normalizeSidebarButton(addEfmInputButton);
+    normalizeSidebarButton(removeEfmInputButton);
+    normalizeSidebarButton(clearEfmInputsButton);
+    efmInputsLayout->setColumnMinimumWidth(1, standardButtonWidth);
+
+    mainLayout->addWidget(efmGroupBox);
+
+    ac3GroupBox = new QGroupBox(tr("AC3 decoder"), this);
+    QGridLayout *ac3Layout = new QGridLayout(ac3GroupBox);
+    ac3Layout->setHorizontalSpacing(6);
+    ac3Layout->setVerticalSpacing(6);
+
+    decodeAc3CheckBox = new QCheckBox(tr("Decode AC3 symbols"), ac3GroupBox);
+    decodeAc3CheckBox->setChecked(false);
+    ac3Layout->addWidget(decodeAc3CheckBox, 0, 0, 1, 4);
+
+    QLabel *ac3InputLabel = new QLabel(tr("AC3 input"), ac3GroupBox);
+    ac3Layout->addWidget(ac3InputLabel, 1, 0, 1, 1);
+    ac3InputLineEdit = new QLineEdit(ac3GroupBox);
+    ac3InputLineEdit->setPlaceholderText(tr("Input symbols file for ac3-decoder"));
+    ac3Layout->addWidget(ac3InputLineEdit, 1, 1, 1, 2);
+    ac3InputBrowseButton = new QPushButton(tr("Browse..."), ac3GroupBox);
+    ac3Layout->addWidget(ac3InputBrowseButton, 1, 3, 1, 1);
+
+    QLabel *ac3OutputLabel = new QLabel(tr("AC3 output"), ac3GroupBox);
+    ac3Layout->addWidget(ac3OutputLabel, 2, 0, 1, 1);
+    ac3OutputLineEdit = new QLineEdit(ac3GroupBox);
+    ac3OutputLineEdit->setPlaceholderText(tr("Output AC3 bitstream file (.ac3)"));
+    ac3Layout->addWidget(ac3OutputLineEdit, 2, 1, 1, 2);
+    ac3OutputBrowseButton = new QPushButton(tr("Browse..."), ac3GroupBox);
+    ac3Layout->addWidget(ac3OutputBrowseButton, 2, 3, 1, 1);
+
+    QLabel *ac3FormatLabel = new QLabel(tr("Input format"), ac3GroupBox);
+    ac3Layout->addWidget(ac3FormatLabel, 3, 0, 1, 1);
+    ac3FormatComboBox = new QComboBox(ac3GroupBox);
+    ac3FormatComboBox->addItem(tr("Auto"), QStringLiteral("auto"));
+    ac3FormatComboBox->addItem(tr("Raw (symbol bytes 0..3)"), QStringLiteral("raw"));
+    ac3FormatComboBox->addItem(tr("ASCII (characters 0..3)"), QStringLiteral("ascii"));
+    ac3Layout->addWidget(ac3FormatComboBox, 3, 1, 1, 2);
+
+    mainLayout->addWidget(ac3GroupBox);
+
+    loadDecodedAudioForExportCheckBox = new QCheckBox(tr("After run, load decoded EFM audio into Export tracks"), this);
+    loadDecodedAudioForExportCheckBox->setChecked(true);
+    mainLayout->addWidget(loadDecodedAudioForExportCheckBox);
+
+    statusLabel = new QLabel(this);
+    statusLabel->setWordWrap(true);
+    mainLayout->addWidget(statusLabel);
+
+    progressBar = new QProgressBar(this);
+    progressBar->setRange(0, 1);
+    progressBar->setValue(0);
+    mainLayout->addWidget(progressBar);
+
+    logTextEdit = new QPlainTextEdit(this);
+    logTextEdit->setReadOnly(true);
+    logTextEdit->setMinimumHeight(96);
+    logTextEdit->setMaximumHeight(140);
+    QFont logFont = logTextEdit->font();
+    logFont.setStyleHint(QFont::TypeWriter);
+    logTextEdit->setFont(logFont);
+    mainLayout->addWidget(logTextEdit);
+
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    buttonLayout->addStretch(1);
+    runButton = new QPushButton(tr("Run selected"), this);
+    cancelButton = new QPushButton(tr("Cancel"), this);
+    closeButton = new QPushButton(tr("Close"), this);
+    buttonLayout->addWidget(runButton);
+    buttonLayout->addWidget(cancelButton);
+    buttonLayout->addWidget(closeButton);
+    mainLayout->addLayout(buttonLayout);
+
+    connect(addEfmInputButton, &QPushButton::clicked, this, &EfmHandlerDialog::onAddEfmInputClicked);
+    connect(removeEfmInputButton, &QPushButton::clicked, this, &EfmHandlerDialog::onRemoveEfmInputClicked);
+    connect(clearEfmInputsButton, &QPushButton::clicked, this, &EfmHandlerDialog::onClearEfmInputsClicked);
+    connect(outputBaseBrowseButton, &QPushButton::clicked, this, &EfmHandlerDialog::onBrowseOutputBaseClicked);
+    connect(audioOutputBrowseButton, &QPushButton::clicked, this, &EfmHandlerDialog::onBrowseAudioOutputClicked);
+    connect(dataOutputBrowseButton, &QPushButton::clicked, this, &EfmHandlerDialog::onBrowseDataOutputClicked);
+    connect(ac3InputBrowseButton, &QPushButton::clicked, this, &EfmHandlerDialog::onBrowseAc3InputClicked);
+    connect(ac3OutputBrowseButton, &QPushButton::clicked, this, &EfmHandlerDialog::onBrowseAc3OutputClicked);
+    connect(runButton, &QPushButton::clicked, this, &EfmHandlerDialog::onRunClicked);
+    connect(cancelButton, &QPushButton::clicked, this, &EfmHandlerDialog::onCancelClicked);
+    connect(closeButton, &QPushButton::clicked, this, &QDialog::close);
+
+    connect(outputBaseLineEdit, &QLineEdit::textEdited, this, [this]() {
+        userEditedOutputBase = true;
+        refreshDerivedOutputPaths(false);
+    });
+    connect(outputBaseLineEdit, &QLineEdit::textChanged, this, [this]() {
+        if (!runInProgress) {
+            refreshDerivedOutputPaths(false);
+        }
+    });
+    connect(audioOutputLineEdit, &QLineEdit::textEdited, this, [this]() {
+        userEditedAudioOutput = true;
+    });
+    connect(dataOutputLineEdit, &QLineEdit::textEdited, this, [this]() {
+        userEditedDataOutput = true;
+    });
+    connect(ac3OutputLineEdit, &QLineEdit::textEdited, this, [this]() {
+        userEditedAc3Output = true;
+    });
+    connect(ac3InputLineEdit, &QLineEdit::textChanged, this, [this]() {
+        if (runInProgress) {
+            return;
+        }
+        const QFileInfo inputInfo(normalizePath(ac3InputLineEdit->text()));
+        if ((!userEditedAc3Output || ac3OutputLineEdit->text().trimmed().isEmpty()) && inputInfo.exists()) {
+            ac3OutputLineEdit->setText(
+                QDir(inputInfo.absolutePath()).filePath(inputInfo.completeBaseName() + QStringLiteral(".ac3")));
+        }
+    });
+
+    auto stateUpdater = [this]() { updateControlStates(); };
+    connect(extractAudioCheckBox, &QCheckBox::toggled, this, stateUpdater);
+    connect(extractDataCheckBox, &QCheckBox::toggled, this, stateUpdater);
+    connect(decodeAc3CheckBox, &QCheckBox::toggled, this, stateUpdater);
+    connect(efmInputListWidget, &QListWidget::itemSelectionChanged, this, stateUpdater);
+    connect(efmInputListWidget, &QListWidget::itemSelectionChanged, this, [this]() {
+        if (!userEditedOutputBase || outputBaseLineEdit->text().trimmed().isEmpty()) {
+            outputBaseLineEdit->setText(defaultOutputBaseFromInputs());
+            userEditedOutputBase = false;
+            refreshDerivedOutputPaths(false);
+        }
+    });
+
+    refreshDerivedOutputPaths(true);
+    updateControlStates();
+}
+
+void EfmHandlerDialog::setBusy(bool enabled)
+{
+    runInProgress = enabled;
+
+    if (enabled) {
+        cancelRequested = false;
+    }
+
+    if (efmGroupBox) {
+        efmGroupBox->setEnabled(!enabled);
+    }
+    if (ac3GroupBox) {
+        ac3GroupBox->setEnabled(!enabled);
+    }
+    if (loadDecodedAudioForExportCheckBox) {
+        loadDecodedAudioForExportCheckBox->setEnabled(!enabled);
+    }
+    if (runButton) {
+        runButton->setEnabled(!enabled);
+    }
+    if (closeButton) {
+        closeButton->setEnabled(!enabled);
+    }
+    if (cancelButton) {
+        cancelButton->setEnabled(enabled);
+    }
+    if (!enabled) {
+        updateControlStates();
+    }
+}
+
+void EfmHandlerDialog::updateControlStates()
+{
+    const bool hasEfmInputs = (efmInputListWidget && efmInputListWidget->count() > 0);
+    const bool multipleEfmInputs = (efmInputListWidget && efmInputListWidget->count() > 1);
+    const bool runDataExtraction = extractDataCheckBox && extractDataCheckBox->isChecked();
+    const bool runAudioExtraction = extractAudioCheckBox && extractAudioCheckBox->isChecked();
+    const bool runAc3Decode = decodeAc3CheckBox && decodeAc3CheckBox->isChecked();
+
+    if (removeEfmInputButton) {
+        removeEfmInputButton->setEnabled(hasEfmInputs && !efmInputListWidget->selectedItems().isEmpty());
+    }
+    if (clearEfmInputsButton) {
+        clearEfmInputsButton->setEnabled(hasEfmInputs);
+    }
+    Q_UNUSED(multipleEfmInputs);
+    if (outputBaseLineEdit) {
+        outputBaseLineEdit->setEnabled(hasEfmInputs);
+    }
+    if (outputBaseBrowseButton) {
+        outputBaseBrowseButton->setEnabled(hasEfmInputs);
+    }
+    if (extractAudioCheckBox) {
+        extractAudioCheckBox->setEnabled(hasEfmInputs);
+    }
+    if (audioOutputLineEdit) {
+        audioOutputLineEdit->setEnabled(hasEfmInputs && runAudioExtraction);
+    }
+    if (audioOutputBrowseButton) {
+        audioOutputBrowseButton->setEnabled(hasEfmInputs && runAudioExtraction);
+    }
+    if (extractDataCheckBox) {
+        extractDataCheckBox->setEnabled(hasEfmInputs);
+    }
+    if (dataOutputLineEdit) {
+        dataOutputLineEdit->setEnabled(hasEfmInputs && runDataExtraction);
+    }
+    if (dataOutputBrowseButton) {
+        dataOutputBrowseButton->setEnabled(hasEfmInputs && runDataExtraction);
+    }
+    if (outputBadSectorMapCheckBox) {
+        outputBadSectorMapCheckBox->setEnabled(hasEfmInputs && runDataExtraction);
+    }
+
+    if (ac3InputLineEdit) {
+        ac3InputLineEdit->setEnabled(runAc3Decode);
+    }
+    if (ac3InputBrowseButton) {
+        ac3InputBrowseButton->setEnabled(runAc3Decode);
+    }
+    if (ac3OutputLineEdit) {
+        ac3OutputLineEdit->setEnabled(runAc3Decode);
+    }
+    if (ac3OutputBrowseButton) {
+        ac3OutputBrowseButton->setEnabled(runAc3Decode);
+    }
+    if (ac3FormatComboBox) {
+        ac3FormatComboBox->setEnabled(runAc3Decode);
+    }
+
+    if (!runInProgress && runButton) {
+        runButton->setEnabled(hasEfmInputs || runAc3Decode);
+    }
+}
+
+QString EfmHandlerDialog::normalizePath(const QString &path) const
+{
+    QString normalized = path.trimmed();
+    normalized.replace(QLatin1Char('\\'), QLatin1Char('/'));
+    if (normalized.isEmpty()) {
+        return QString();
+    }
+    return QDir::cleanPath(normalized);
+}
+
+QString EfmHandlerDialog::defaultOutputBaseFromInputs() const
+{
+    if (!efmInputListWidget || efmInputListWidget->count() == 0) {
+        return QString();
+    }
+    QListWidgetItem *firstItem = efmInputListWidget->item(0);
+    if (!firstItem) {
+        return QString();
+    }
+    const QFileInfo inputInfo(normalizePath(firstItem->text()));
+    if (!inputInfo.exists()) {
+        return QString();
+    }
+    QString baseName = inputInfo.completeBaseName();
+    if (baseName.isEmpty()) {
+        baseName = QStringLiteral("efm_output");
+    }
+    return QDir(inputInfo.absolutePath()).filePath(baseName);
+}
+
+void EfmHandlerDialog::refreshDerivedOutputPaths(bool forceUpdate)
+{
+    const QString outputBase = normalizePath(outputBaseLineEdit ? outputBaseLineEdit->text() : QString());
+    if (!outputBase.isEmpty()) {
+        if (audioOutputLineEdit && (forceUpdate || !userEditedAudioOutput || audioOutputLineEdit->text().trimmed().isEmpty())) {
+            audioOutputLineEdit->setText(outputBase + QStringLiteral(".wav"));
+            if (forceUpdate) {
+                userEditedAudioOutput = false;
+            }
+        }
+        if (dataOutputLineEdit && (forceUpdate || !userEditedDataOutput || dataOutputLineEdit->text().trimmed().isEmpty())) {
+            dataOutputLineEdit->setText(outputBase + QStringLiteral(".bin"));
+            if (forceUpdate) {
+                userEditedDataOutput = false;
+            }
+        }
+    }
+
+    const QFileInfo ac3InputInfo(normalizePath(ac3InputLineEdit ? ac3InputLineEdit->text() : QString()));
+    if (ac3OutputLineEdit && ac3InputInfo.exists()) {
+        if (forceUpdate || !userEditedAc3Output || ac3OutputLineEdit->text().trimmed().isEmpty()) {
+            ac3OutputLineEdit->setText(
+                QDir(ac3InputInfo.absolutePath()).filePath(ac3InputInfo.completeBaseName() + QStringLiteral(".ac3")));
+            if (forceUpdate) {
+                userEditedAc3Output = false;
+            }
+        }
+    }
+}
+
+void EfmHandlerDialog::appendStatus(const QString &text)
+{
+    if (statusLabel) {
+        statusLabel->setText(text);
+    }
+}
+
+void EfmHandlerDialog::appendLog(const QString &text)
+{
+    if (!logTextEdit) {
+        return;
+    }
+    const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("HH:mm:ss"));
+    logTextEdit->appendPlainText(QStringLiteral("[%1] %2").arg(timestamp, text));
+    QScrollBar *scrollBar = logTextEdit->verticalScrollBar();
+    if (scrollBar) {
+        scrollBar->setValue(scrollBar->maximum());
+    }
+}
+
+QString EfmHandlerDialog::formatCommand(const QString &program, const QStringList &arguments) const
+{
+    QStringList commandParts;
+    commandParts << quoteForShell(program);
+    for (const QString &argument : arguments) {
+        commandParts << quoteForShell(argument);
+    }
+    return commandParts.join(QLatin1Char(' '));
+}
+
+QString EfmHandlerDialog::resolveExternalExecutable(const QStringList &toolNames) const
+{
+    if (toolNames.isEmpty()) {
+        return QString();
+    }
+
+    QStringList candidateNames;
+    for (const QString &toolName : toolNames) {
+        appendUniqueCaseInsensitive(&candidateNames, toolName.trimmed());
+#if defined(Q_OS_WIN)
+        if (!toolName.endsWith(QStringLiteral(".exe"), Qt::CaseInsensitive)) {
+            appendUniqueCaseInsensitive(&candidateNames, toolName.trimmed() + QStringLiteral(".exe"));
+        }
+#endif
+    }
+
+    QStringList searchRoots;
+    const QString appDir = QCoreApplication::applicationDirPath();
+    appendUniqueCaseInsensitive(&searchRoots, appDir);
+    appendUniqueCaseInsensitive(&searchRoots, QDir(appDir).filePath(QStringLiteral(".")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir(appDir).filePath(QStringLiteral("..")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir(appDir).filePath(QStringLiteral("../bin")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir(appDir).filePath(QStringLiteral("../../bin")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir(appDir).filePath(QStringLiteral("../../../bin")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir::currentPath());
+    appendUniqueCaseInsensitive(&searchRoots, QDir(QDir::currentPath()).filePath(QStringLiteral("bin")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir(QDir::currentPath()).filePath(QStringLiteral("build/bin")));
+    appendUniqueCaseInsensitive(&searchRoots, QDir(QDir::currentPath()).filePath(QStringLiteral("../build/bin")));
+
+    for (const QString &root : searchRoots) {
+        if (root.isEmpty()) {
+            continue;
+        }
+        const QDir rootDir(root);
+        for (const QString &candidateName : candidateNames) {
+            const QString candidatePath = rootDir.filePath(candidateName);
+            if (isRunnableFile(candidatePath)) {
+                return candidatePath;
+            }
+        }
+    }
+
+    for (const QString &candidateName : candidateNames) {
+        const QString fromPath = QStandardPaths::findExecutable(candidateName);
+        if (!fromPath.isEmpty() && isRunnableFile(fromPath)) {
+            return fromPath;
+        }
+    }
+
+    return QString();
+}
+
+bool EfmHandlerDialog::runProcessStep(const CommandStep &step,
+                                      int stepNumberOneBased,
+                                      int totalSteps,
+                                      QString *errorMessage)
+{
+    if (errorMessage) {
+        errorMessage->clear();
+    }
+
+    appendStatus(tr("Running step %1/%2: %3").arg(stepNumberOneBased).arg(totalSteps).arg(step.title));
+    appendLog(tr("----- Step %1/%2: %3 -----").arg(stepNumberOneBased).arg(totalSteps).arg(step.title));
+    appendLog(QStringLiteral("$ %1").arg(formatCommand(step.program, step.arguments)));
+
+    QProcess process;
+    process.setProcessChannelMode(QProcess::MergedChannels);
+    process.start(step.program, step.arguments);
+
+    if (!process.waitForStarted(5000)) {
+        if (errorMessage) {
+            *errorMessage = tr("Unable to start tool: %1").arg(step.program);
+        }
+        return false;
+    }
+
+    QByteArray pendingOutputBuffer;
+    QString lastOutputLine;
+    bool terminateSent = false;
+    QElapsedTimer cancelTimer;
+
+    auto consumeOutputChunk = [&](const QByteArray &chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+
+        QByteArray normalized = chunk;
+        normalized.replace('\r', '\n');
+        pendingOutputBuffer.append(normalized);
+
+        qsizetype lineBreakIndex = -1;
+        while ((lineBreakIndex = pendingOutputBuffer.indexOf('\n')) >= 0) {
+            QByteArray lineBytes = pendingOutputBuffer.left(lineBreakIndex);
+            pendingOutputBuffer.remove(0, lineBreakIndex + 1);
+            const QString lineText = QString::fromLocal8Bit(lineBytes).trimmed();
+            if (lineText.isEmpty()) {
+                continue;
+            }
+            lastOutputLine = lineText;
+            appendLog(lineText);
+        }
+    };
+
+    while (process.state() != QProcess::NotRunning) {
+        if (cancelRequested) {
+            if (!terminateSent) {
+                process.terminate();
+                terminateSent = true;
+                cancelTimer.start();
+            } else if (cancelTimer.isValid() && cancelTimer.elapsed() > 2000) {
+                process.kill();
+            }
+        }
+
+        process.waitForReadyRead(100);
+        consumeOutputChunk(process.readAllStandardOutput());
+        QCoreApplication::processEvents();
+    }
+
+    consumeOutputChunk(process.readAllStandardOutput());
+    if (!pendingOutputBuffer.trimmed().isEmpty()) {
+        const QString trailingLine = QString::fromLocal8Bit(pendingOutputBuffer).trimmed();
+        if (!trailingLine.isEmpty()) {
+            lastOutputLine = trailingLine;
+            appendLog(trailingLine);
+        }
+    }
+
+    if (cancelRequested) {
+        if (errorMessage) {
+            *errorMessage = tr("Cancelled by user.");
+        }
+        return false;
+    }
+
+    if (process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0) {
+        if (errorMessage) {
+            *errorMessage = !lastOutputLine.isEmpty()
+                                ? lastOutputLine
+                                : tr("%1 failed with exit code %2.").arg(step.title).arg(process.exitCode());
+        }
+        return false;
+    }
+
+    appendLog(tr("Completed: %1").arg(step.title));
+    return true;
+}
+
+bool EfmHandlerDialog::runSelectedWorkflows(QString *errorMessage, QStringList *generatedAudioTracks)
+{
+    if (errorMessage) {
+        errorMessage->clear();
+    }
+    if (generatedAudioTracks) {
+        generatedAudioTracks->clear();
+    }
+
+    const bool runAc3 = decodeAc3CheckBox && decodeAc3CheckBox->isChecked();
+    const bool hasEfmInputs = efmInputListWidget && efmInputListWidget->count() > 0;
+    const bool runEfmAudio = extractAudioCheckBox && extractAudioCheckBox->isChecked();
+    const bool runEfmData = extractDataCheckBox && extractDataCheckBox->isChecked();
+
+    if (!hasEfmInputs && !runAc3) {
+        if (errorMessage) {
+            *errorMessage = tr("Add at least one EFM input or enable AC3 decoding.");
+        }
+        return false;
+    }
+
+    QStringList efmInputs;
+    if (hasEfmInputs) {
+        for (int index = 0; index < efmInputListWidget->count(); ++index) {
+            QListWidgetItem *item = efmInputListWidget->item(index);
+            if (!item) {
+                continue;
+            }
+            const QString inputPath = QFileInfo(normalizePath(item->text())).absoluteFilePath();
+            if (inputPath.isEmpty()) {
+                continue;
+            }
+            if (!QFileInfo::exists(inputPath) || !QFileInfo(inputPath).isFile()) {
+                if (errorMessage) {
+                    *errorMessage = tr("EFM input does not exist:\n%1").arg(inputPath);
+                }
+                return false;
+            }
+            efmInputs << inputPath;
+        }
+    }
+
+    if (hasEfmInputs && efmInputs.isEmpty()) {
+        if (errorMessage) {
+            *errorMessage = tr("No valid EFM input files were provided.");
+        }
+        return false;
+    }
+
+    const QString outputBase = QFileInfo(normalizePath(outputBaseLineEdit ? outputBaseLineEdit->text() : QString()))
+                                   .absoluteFilePath();
+    const QString audioOutputPath = QFileInfo(normalizePath(audioOutputLineEdit ? audioOutputLineEdit->text() : QString()))
+                                        .absoluteFilePath();
+    const QString dataOutputPath = QFileInfo(normalizePath(dataOutputLineEdit ? dataOutputLineEdit->text() : QString()))
+                                       .absoluteFilePath();
+
+    if (hasEfmInputs && outputBase.trimmed().isEmpty()) {
+        if (errorMessage) {
+            *errorMessage = tr("Please select an EFM output base path.");
+        }
+        return false;
+    }
+    if (runEfmAudio && audioOutputPath.trimmed().isEmpty()) {
+        if (errorMessage) {
+            *errorMessage = tr("Please select an audio output file path.");
+        }
+        return false;
+    }
+    if (runEfmData && dataOutputPath.trimmed().isEmpty()) {
+        if (errorMessage) {
+            *errorMessage = tr("Please select a data output file path.");
+        }
+        return false;
+    }
+    if (efmInputs.size() > 1 && (!stackF2CheckBox || !stackF2CheckBox->isChecked())) {
+        if (errorMessage) {
+            *errorMessage = tr("Multiple EFM inputs require \"Stack multiple sources before D24\".");
+        }
+        return false;
+    }
+
+    const QString ac3InputPath = QFileInfo(normalizePath(ac3InputLineEdit ? ac3InputLineEdit->text() : QString()))
+                                     .absoluteFilePath();
+    const QString ac3OutputPath = QFileInfo(normalizePath(ac3OutputLineEdit ? ac3OutputLineEdit->text() : QString()))
+                                      .absoluteFilePath();
+    const QString ac3Format = ac3FormatComboBox
+                                  ? ac3FormatComboBox->currentData().toString().trimmed().toLower()
+                                  : QStringLiteral("auto");
+    if (runAc3) {
+        if (ac3InputPath.trimmed().isEmpty() || !QFileInfo::exists(ac3InputPath)) {
+            if (errorMessage) {
+                *errorMessage = tr("Please select a valid AC3 input symbols file.");
+            }
+            return false;
+        }
+        if (ac3OutputPath.trimmed().isEmpty()) {
+            if (errorMessage) {
+                *errorMessage = tr("Please select an AC3 output file path.");
+            }
+            return false;
+        }
+    }
+
+    QString efmF2Tool;
+    QString efmStackTool;
+    QString efmD24Tool;
+    QString efmAudioTool;
+    QString efmDataTool;
+    QString ac3Tool;
+
+    if (!efmInputs.isEmpty()) {
+        efmF2Tool = resolveExternalExecutable({QStringLiteral("efm-decoder-f2")});
+        efmD24Tool = resolveExternalExecutable({QStringLiteral("efm-decoder-d24")});
+        if (efmF2Tool.isEmpty() || efmD24Tool.isEmpty()) {
+            if (errorMessage) {
+                *errorMessage = tr("efm-decoder-f2 and/or efm-decoder-d24 were not found.");
+            }
+            return false;
+        }
+        if (efmInputs.size() > 1) {
+            efmStackTool = resolveExternalExecutable({QStringLiteral("efm-stacker-f2")});
+            if (efmStackTool.isEmpty()) {
+                if (errorMessage) {
+                    *errorMessage = tr("efm-stacker-f2 was not found.");
+                }
+                return false;
+            }
+        }
+        if (runEfmAudio) {
+            efmAudioTool = resolveExternalExecutable({QStringLiteral("efm-decoder-audio")});
+            if (efmAudioTool.isEmpty()) {
+                if (errorMessage) {
+                    *errorMessage = tr("efm-decoder-audio was not found.");
+                }
+                return false;
+            }
+        }
+        if (runEfmData) {
+            efmDataTool = resolveExternalExecutable({QStringLiteral("efm-decoder-data")});
+            if (efmDataTool.isEmpty()) {
+                if (errorMessage) {
+                    *errorMessage = tr("efm-decoder-data was not found.");
+                }
+                return false;
+            }
+        }
+    }
+
+    if (runAc3) {
+        ac3Tool = resolveExternalExecutable({QStringLiteral("ac3-decoder")});
+        if (ac3Tool.isEmpty()) {
+            if (errorMessage) {
+                *errorMessage = tr("ac3-decoder was not found.");
+            }
+            return false;
+        }
+    }
+
+    QTemporaryDir tempDirectory;
+    if (!efmInputs.isEmpty() && !tempDirectory.isValid()) {
+        if (errorMessage) {
+            *errorMessage = tr("Unable to create a temporary directory for EFM intermediate files.");
+        }
+        return false;
+    }
+
+    QList<CommandStep> commandSteps;
+    QStringList f2Outputs;
+    QString selectedF2Input;
+    QString d24OutputPath;
+
+    if (!efmInputs.isEmpty()) {
+        for (int inputIndex = 0; inputIndex < efmInputs.size(); ++inputIndex) {
+            const QString efmInputPath = efmInputs.at(inputIndex);
+            const QString f2OutputPath = QDir(tempDirectory.path()).filePath(
+                QStringLiteral("efm_input_%1.f2").arg(inputIndex + 1, 2, 10, QChar('0')));
+            QStringList f2Arguments;
+            if (noTimecodesCheckBox && noTimecodesCheckBox->isChecked()) {
+                f2Arguments << QStringLiteral("--no-timecodes");
+            }
+            f2Arguments << efmInputPath << f2OutputPath;
+            commandSteps.append({tr("EFM to F2 (%1/%2)").arg(inputIndex + 1).arg(efmInputs.size()),
+                                 efmF2Tool,
+                                 f2Arguments});
+            f2Outputs << f2OutputPath;
+        }
+
+        if (f2Outputs.size() > 1) {
+            selectedF2Input = QDir(tempDirectory.path()).filePath(QStringLiteral("efm_stacked.f2"));
+            QStringList stackArguments = f2Outputs;
+            stackArguments << selectedF2Input;
+            commandSteps.append({tr("Stack F2 sources"), efmStackTool, stackArguments});
+        } else {
+            selectedF2Input = f2Outputs.constFirst();
+        }
+
+        d24OutputPath = outputBase + QStringLiteral(".d24");
+        commandSteps.append({tr("F2 to D24"), efmD24Tool, {selectedF2Input, d24OutputPath}});
+
+        if (runEfmAudio) {
+            commandSteps.append({tr("D24 to audio"), efmAudioTool, {d24OutputPath, audioOutputPath}});
+        }
+        if (runEfmData) {
+            QStringList dataArguments;
+            if (outputBadSectorMapCheckBox && outputBadSectorMapCheckBox->isChecked()) {
+                dataArguments << QStringLiteral("--output-metadata");
+            }
+            dataArguments << d24OutputPath << dataOutputPath;
+            commandSteps.append({tr("D24 to data"), efmDataTool, dataArguments});
+        }
+    }
+
+    if (runAc3) {
+        QStringList ac3Arguments;
+        if (ac3Format != QStringLiteral("auto")) {
+            ac3Arguments << QStringLiteral("--format") << ac3Format;
+        }
+        ac3Arguments << ac3InputPath << ac3OutputPath;
+        commandSteps.append({tr("AC3 symbol decode"), ac3Tool, ac3Arguments});
+    }
+
+    if (commandSteps.isEmpty()) {
+        if (errorMessage) {
+            *errorMessage = tr("No runnable workflow was selected.");
+        }
+        return false;
+    }
+
+    if (progressBar) {
+        progressBar->setRange(0, commandSteps.size());
+        progressBar->setValue(0);
+    }
+
+    for (int commandIndex = 0; commandIndex < commandSteps.size(); ++commandIndex) {
+        QString stepError;
+        if (!runProcessStep(commandSteps.at(commandIndex), commandIndex + 1, commandSteps.size(), &stepError)) {
+            if (errorMessage) {
+                *errorMessage = stepError;
+            }
+            return false;
+        }
+        if (progressBar) {
+            progressBar->setValue(commandIndex + 1);
+        }
+    }
+
+    if (generatedAudioTracks && runEfmAudio) {
+        generatedAudioTracks->append(QFileInfo(audioOutputPath).absoluteFilePath());
+    }
+
+    return true;
+}
+
+void EfmHandlerDialog::onAddEfmInputClicked()
+{
+    const QString startDirectory = chooseStartDirectory(sourceDirectory);
+    const QStringList selectedFiles = QFileDialog::getOpenFileNames(
+        this,
+        tr("Select EFM input files"),
+        startDirectory,
+        tr("EFM files (*.efm);;All Files (*)"));
+    if (selectedFiles.isEmpty()) {
+        return;
+    }
+
+    bool addedAny = false;
+    for (const QString &selectedFile : selectedFiles) {
+        const QString normalizedPath = QFileInfo(normalizePath(selectedFile)).absoluteFilePath();
+        if (normalizedPath.isEmpty() || !QFileInfo::exists(normalizedPath)) {
+            continue;
+        }
+        bool alreadyListed = false;
+        for (int index = 0; index < efmInputListWidget->count(); ++index) {
+            QListWidgetItem *item = efmInputListWidget->item(index);
+            if (item && item->text().compare(normalizedPath, Qt::CaseInsensitive) == 0) {
+                alreadyListed = true;
+                break;
+            }
+        }
+        if (alreadyListed) {
+            continue;
+        }
+        efmInputListWidget->addItem(normalizedPath);
+        sourceDirectory = QFileInfo(normalizedPath).absolutePath();
+        addedAny = true;
+    }
+
+    if (addedAny && (!userEditedOutputBase || outputBaseLineEdit->text().trimmed().isEmpty())) {
+        outputBaseLineEdit->setText(defaultOutputBaseFromInputs());
+        userEditedOutputBase = false;
+        refreshDerivedOutputPaths(false);
+    }
+    updateControlStates();
+}
+
+void EfmHandlerDialog::onRemoveEfmInputClicked()
+{
+    const QList<QListWidgetItem *> selectedItems = efmInputListWidget->selectedItems();
+    for (QListWidgetItem *selectedItem : selectedItems) {
+        delete efmInputListWidget->takeItem(efmInputListWidget->row(selectedItem));
+    }
+
+    if (efmInputListWidget->count() == 0 && !userEditedOutputBase) {
+        outputBaseLineEdit->clear();
+    }
+    updateControlStates();
+}
+
+void EfmHandlerDialog::onClearEfmInputsClicked()
+{
+    efmInputListWidget->clear();
+    if (!userEditedOutputBase) {
+        outputBaseLineEdit->clear();
+    }
+    updateControlStates();
+}
+
+void EfmHandlerDialog::onBrowseOutputBaseClicked()
+{
+    QString suggestedPath = normalizePath(outputBaseLineEdit->text());
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = defaultOutputBaseFromInputs();
+    }
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = chooseStartDirectory(sourceDirectory);
+    }
+
+    const QString selectedPath = QFileDialog::getSaveFileName(
+        this,
+        tr("Select output base path"),
+        suggestedPath,
+        tr("All Files (*)"));
+    if (selectedPath.isEmpty()) {
+        return;
+    }
+
+    userEditedOutputBase = true;
+    outputBaseLineEdit->setText(normalizePath(selectedPath));
+    refreshDerivedOutputPaths(false);
+}
+
+void EfmHandlerDialog::onBrowseAudioOutputClicked()
+{
+    QString suggestedPath = normalizePath(audioOutputLineEdit->text());
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = normalizePath(outputBaseLineEdit->text()) + QStringLiteral(".wav");
+    }
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = chooseStartDirectory(sourceDirectory);
+    }
+
+    const QString selectedPath = QFileDialog::getSaveFileName(
+        this,
+        tr("Select audio output"),
+        suggestedPath,
+        tr("WAV audio (*.wav);;All Files (*)"));
+    if (selectedPath.isEmpty()) {
+        return;
+    }
+
+    userEditedAudioOutput = true;
+    audioOutputLineEdit->setText(normalizePath(selectedPath));
+}
+
+void EfmHandlerDialog::onBrowseDataOutputClicked()
+{
+    QString suggestedPath = normalizePath(dataOutputLineEdit->text());
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = normalizePath(outputBaseLineEdit->text()) + QStringLiteral(".bin");
+    }
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = chooseStartDirectory(sourceDirectory);
+    }
+
+    const QString selectedPath = QFileDialog::getSaveFileName(
+        this,
+        tr("Select data output"),
+        suggestedPath,
+        tr("Binary data (*.bin *.dat);;All Files (*)"));
+    if (selectedPath.isEmpty()) {
+        return;
+    }
+
+    userEditedDataOutput = true;
+    dataOutputLineEdit->setText(normalizePath(selectedPath));
+}
+
+void EfmHandlerDialog::onBrowseAc3InputClicked()
+{
+    const QString startDirectory = chooseStartDirectory(sourceDirectory);
+    const QString selectedPath = QFileDialog::getOpenFileName(
+        this,
+        tr("Select AC3 symbols input"),
+        startDirectory,
+        tr("All Files (*)"));
+    if (selectedPath.isEmpty()) {
+        return;
+    }
+
+    const QString normalizedInputPath = normalizePath(selectedPath);
+    ac3InputLineEdit->setText(normalizedInputPath);
+    sourceDirectory = QFileInfo(normalizedInputPath).absolutePath();
+    if (!userEditedAc3Output || ac3OutputLineEdit->text().trimmed().isEmpty()) {
+        const QFileInfo inputInfo(normalizedInputPath);
+        ac3OutputLineEdit->setText(
+            QDir(inputInfo.absolutePath()).filePath(inputInfo.completeBaseName() + QStringLiteral(".ac3")));
+    }
+}
+
+void EfmHandlerDialog::onBrowseAc3OutputClicked()
+{
+    QString suggestedPath = normalizePath(ac3OutputLineEdit->text());
+    if (suggestedPath.isEmpty()) {
+        const QFileInfo inputInfo(normalizePath(ac3InputLineEdit->text()));
+        if (inputInfo.exists()) {
+            suggestedPath = QDir(inputInfo.absolutePath()).filePath(inputInfo.completeBaseName() + QStringLiteral(".ac3"));
+        }
+    }
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = chooseStartDirectory(sourceDirectory);
+    }
+
+    const QString selectedPath = QFileDialog::getSaveFileName(
+        this,
+        tr("Select AC3 output"),
+        suggestedPath,
+        tr("AC3 bitstream (*.ac3);;All Files (*)"));
+    if (selectedPath.isEmpty()) {
+        return;
+    }
+
+    userEditedAc3Output = true;
+    ac3OutputLineEdit->setText(normalizePath(selectedPath));
+}
+
+void EfmHandlerDialog::onRunClicked()
+{
+    if (runInProgress) {
+        return;
+    }
+
+    cancelRequested = false;
+    QStringList generatedAudioTracks;
+    QString runError;
+
+    appendLog(tr("Starting EFM-Handler run"));
+    setBusy(true);
+
+    const bool success = runSelectedWorkflows(&runError, &generatedAudioTracks);
+    setBusy(false);
+
+    if (!success) {
+        if (runError.contains(tr("cancelled"), Qt::CaseInsensitive)) {
+            appendStatus(tr("Run cancelled."));
+            appendLog(tr("Run cancelled by user."));
+            return;
+        }
+        appendStatus(tr("Run failed."));
+        QMessageBox::warning(this,
+                             tr("EFM-Handler"),
+                             runError.isEmpty() ? tr("Run failed.") : runError);
+        return;
+    }
+
+    appendStatus(tr("Run complete."));
+    appendLog(tr("Run complete."));
+
+    if (!generatedAudioTracks.isEmpty()
+        && loadDecodedAudioForExportCheckBox
+        && loadDecodedAudioForExportCheckBox->isChecked()) {
+        QStringList trackNames;
+        trackNames.reserve(generatedAudioTracks.size());
+        for (int index = 0; index < generatedAudioTracks.size(); ++index) {
+            trackNames << tr("EFM Audio");
+        }
+        emit exportTracksPrepared(generatedAudioTracks, trackNames);
+    }
+
+    QMessageBox::information(this,
+                             tr("EFM-Handler"),
+                             tr("Selected workflows completed successfully."));
+}
+
+void EfmHandlerDialog::onCancelClicked()
+{
+    if (runInProgress) {
+        cancelRequested = true;
+        appendStatus(tr("Cancelling..."));
+        appendLog(tr("Cancellation requested..."));
+        return;
+    }
+    close();
+}

--- a/src/ld-analyse/efmhandlerdialog.h
+++ b/src/ld-analyse/efmhandlerdialog.h
@@ -34,6 +34,7 @@ public:
 
     void setSourceDirectory(const QString &directory);
     void setDefaultEfmInput(const QString &efmFilename);
+    void setDefaultAc3Input(const QString &ac3Filename);
     void setSuggestedOutputBase(const QString &outputBasePath);
 
 signals:

--- a/src/ld-analyse/efmhandlerdialog.h
+++ b/src/ld-analyse/efmhandlerdialog.h
@@ -1,0 +1,119 @@
+/******************************************************************************
+ * efmhandlerdialog.h
+ * ld-analyse - Dedicated EFM/AC3 handling workflow GUI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Simon Inns
+ *
+ * This file is part of ld-decode-tools.
+ ******************************************************************************/
+
+#ifndef EFMHANDLERDIALOG_H
+#define EFMHANDLERDIALOG_H
+
+#include <QDialog>
+#include <QStringList>
+
+class QCheckBox;
+class QComboBox;
+class QGroupBox;
+class QLabel;
+class QLineEdit;
+class QListWidget;
+class QPlainTextEdit;
+class QProgressBar;
+class QPushButton;
+
+class EfmHandlerDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit EfmHandlerDialog(QWidget *parent = nullptr);
+    ~EfmHandlerDialog() override = default;
+
+    void setSourceDirectory(const QString &directory);
+    void setDefaultEfmInput(const QString &efmFilename);
+    void setSuggestedOutputBase(const QString &outputBasePath);
+
+signals:
+    void exportTracksPrepared(const QStringList &trackFiles, const QStringList &trackNames);
+
+private slots:
+    void onAddEfmInputClicked();
+    void onRemoveEfmInputClicked();
+    void onClearEfmInputsClicked();
+    void onBrowseOutputBaseClicked();
+    void onBrowseAudioOutputClicked();
+    void onBrowseDataOutputClicked();
+    void onBrowseAc3InputClicked();
+    void onBrowseAc3OutputClicked();
+    void onRunClicked();
+    void onCancelClicked();
+
+private:
+    struct CommandStep {
+        QString title;
+        QString program;
+        QStringList arguments;
+    };
+
+    void buildUi();
+    void setBusy(bool enabled);
+    void updateControlStates();
+    QString normalizePath(const QString &path) const;
+    QString defaultOutputBaseFromInputs() const;
+    void refreshDerivedOutputPaths(bool forceUpdate);
+    void appendStatus(const QString &text);
+    void appendLog(const QString &text);
+    QString formatCommand(const QString &program, const QStringList &arguments) const;
+    QString resolveExternalExecutable(const QStringList &toolNames) const;
+    bool runProcessStep(const CommandStep &step,
+                        int stepNumberOneBased,
+                        int totalSteps,
+                        QString *errorMessage);
+    bool runSelectedWorkflows(QString *errorMessage, QStringList *generatedAudioTracks);
+
+    QString sourceDirectory;
+    bool runInProgress = false;
+    bool cancelRequested = false;
+    bool userEditedOutputBase = false;
+    bool userEditedAudioOutput = false;
+    bool userEditedDataOutput = false;
+    bool userEditedAc3Output = false;
+
+    QGroupBox *efmGroupBox = nullptr;
+    QListWidget *efmInputListWidget = nullptr;
+    QPushButton *addEfmInputButton = nullptr;
+    QPushButton *removeEfmInputButton = nullptr;
+    QPushButton *clearEfmInputsButton = nullptr;
+    QCheckBox *noTimecodesCheckBox = nullptr;
+    QCheckBox *stackF2CheckBox = nullptr;
+    QLineEdit *outputBaseLineEdit = nullptr;
+    QPushButton *outputBaseBrowseButton = nullptr;
+    QCheckBox *extractAudioCheckBox = nullptr;
+    QLineEdit *audioOutputLineEdit = nullptr;
+    QPushButton *audioOutputBrowseButton = nullptr;
+    QCheckBox *extractDataCheckBox = nullptr;
+    QLineEdit *dataOutputLineEdit = nullptr;
+    QPushButton *dataOutputBrowseButton = nullptr;
+    QCheckBox *outputBadSectorMapCheckBox = nullptr;
+
+    QGroupBox *ac3GroupBox = nullptr;
+    QCheckBox *decodeAc3CheckBox = nullptr;
+    QLineEdit *ac3InputLineEdit = nullptr;
+    QPushButton *ac3InputBrowseButton = nullptr;
+    QLineEdit *ac3OutputLineEdit = nullptr;
+    QPushButton *ac3OutputBrowseButton = nullptr;
+    QComboBox *ac3FormatComboBox = nullptr;
+
+    QCheckBox *loadDecodedAudioForExportCheckBox = nullptr;
+    QLabel *statusLabel = nullptr;
+    QProgressBar *progressBar = nullptr;
+    QPlainTextEdit *logTextEdit = nullptr;
+    QPushButton *runButton = nullptr;
+    QPushButton *cancelButton = nullptr;
+    QPushButton *closeButton = nullptr;
+};
+
+#endif // EFMHANDLERDIALOG_H

--- a/src/ld-analyse/exportdialog.cpp
+++ b/src/ld-analyse/exportdialog.cpp
@@ -1694,6 +1694,26 @@ void ExportDialog::setOutPoint(int frameNumber)
     syncRangeTimecodeEditors();
 }
 
+bool ExportDialog::hasAudioTracksConfigured() const
+{
+    if (!ui) {
+        return false;
+    }
+
+    const QStringList trackCandidates = {
+        ui->audio1LineEdit ? ui->audio1LineEdit->text().trimmed() : QString(),
+        ui->audio2LineEdit ? ui->audio2LineEdit->text().trimmed() : QString(),
+        ui->audio3LineEdit ? ui->audio3LineEdit->text().trimmed() : QString(),
+        ui->audio4LineEdit ? ui->audio4LineEdit->text().trimmed() : QString()
+    };
+    for (const QString &candidate : trackCandidates) {
+        if (!candidate.isEmpty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void ExportDialog::loadAudioTracksForExport(const QStringList &trackFiles, const QStringList &trackNames)
 {
     if (!ui) {
@@ -2376,7 +2396,7 @@ void ExportDialog::on_audio1BrowseButton_clicked()
     const QString selected = runOpenFileDialog(this,
                                                tr("Select audio track 1"),
                                                currentInputFile.isEmpty() ? QString() : QFileInfo(currentInputFile).absolutePath(),
-                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg);;All Files (*)"));
+                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg *.pcm);;All Files (*)"));
     if (!selected.isEmpty()) {
         ui->audio1LineEdit->setText(selected);
     }
@@ -2387,7 +2407,7 @@ void ExportDialog::on_audio2BrowseButton_clicked()
     const QString selected = runOpenFileDialog(this,
                                                tr("Select audio track 2"),
                                                currentInputFile.isEmpty() ? QString() : QFileInfo(currentInputFile).absolutePath(),
-                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg);;All Files (*)"));
+                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg *.pcm);;All Files (*)"));
     if (!selected.isEmpty()) {
         ui->audio2LineEdit->setText(selected);
     }
@@ -2398,7 +2418,7 @@ void ExportDialog::on_audio3BrowseButton_clicked()
     const QString selected = runOpenFileDialog(this,
                                                tr("Select audio track 3"),
                                                currentInputFile.isEmpty() ? QString() : QFileInfo(currentInputFile).absolutePath(),
-                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg);;All Files (*)"));
+                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg *.pcm);;All Files (*)"));
     if (!selected.isEmpty()) {
         ui->audio3LineEdit->setText(selected);
     }
@@ -2409,7 +2429,7 @@ void ExportDialog::on_audio4BrowseButton_clicked()
     const QString selected = runOpenFileDialog(this,
                                                tr("Select audio track 4"),
                                                currentInputFile.isEmpty() ? QString() : QFileInfo(currentInputFile).absolutePath(),
-                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg);;All Files (*)"));
+                                               tr("Audio Files (*.wav *.flac *.aiff *.aif *.mp3 *.m4a *.aac *.ogg *.pcm);;All Files (*)"));
     if (!selected.isEmpty()) {
         ui->audio4LineEdit->setText(selected);
     }
@@ -4436,14 +4456,20 @@ bool ExportDialog::prepareTrimmedAudioTracks(int zeroBasedStartFrame,
             QStringLiteral("ld-analyse-audio-range-%1-%2.wav")
                 .arg(index + 1)
                 .arg(QUuid::createUuid().toString(QUuid::WithoutBraces)));
+        const bool isRawPcmTrack = sourceInfo.suffix().compare(QStringLiteral("pcm"), Qt::CaseInsensitive) == 0;
         QStringList ffmpegArgs;
         ffmpegArgs << QStringLiteral("-hide_banner")
                    << QStringLiteral("-v") << QStringLiteral("error")
                    << QStringLiteral("-nostdin")
                    << QStringLiteral("-y")
                    << QStringLiteral("-ss") << startArg
-                   << QStringLiteral("-t") << durationArg
-                   << QStringLiteral("-i") << sourceTrack
+                   << QStringLiteral("-t") << durationArg;
+        if (isRawPcmTrack) {
+            ffmpegArgs << QStringLiteral("-f") << QStringLiteral("s16le")
+                       << QStringLiteral("-ar") << QStringLiteral("44100")
+                       << QStringLiteral("-ac") << QStringLiteral("2");
+        }
+        ffmpegArgs << QStringLiteral("-i") << sourceTrack
                    << QStringLiteral("-map") << QStringLiteral("0:a:0")
                    << QStringLiteral("-vn")
                    << QStringLiteral("-sn")
@@ -4663,6 +4689,21 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
             continue;
         }
         const QString title = (i < trackTitles.size()) ? trackTitles.at(i).trimmed() : QString();
+        const bool isRawPcmTrack =
+            QFileInfo(track).suffix().compare(QStringLiteral("pcm"), Qt::CaseInsensitive) == 0;
+        if (isRawPcmTrack) {
+            QJsonArray advancedTrack;
+            advancedTrack.append(track);
+            advancedTrack.append(title.isEmpty() ? QJsonValue(QJsonValue::Null)
+                                                 : QJsonValue(title));
+            advancedTrack.append(QJsonValue(QJsonValue::Null));
+            advancedTrack.append(44100);
+            advancedTrack.append(QStringLiteral("s16le"));
+            advancedTrack.append(2);
+            args << QStringLiteral("--audio-track-advanced")
+                 << QString::fromUtf8(QJsonDocument(advancedTrack).toJson(QJsonDocument::Compact));
+            continue;
+        }
         if (!title.isEmpty()) {
             QJsonArray advancedTrack;
             advancedTrack.append(track);

--- a/src/ld-analyse/exportdialog.cpp
+++ b/src/ld-analyse/exportdialog.cpp
@@ -29,11 +29,23 @@
 #include <QTableWidgetItem>
 #include <QHeaderView>
 #include <QAbstractItemView>
+#include <QSizePolicy>
+#include <QSplitter>
 #include <QTimer>
+#include <QUrl>
 #include <algorithm>
 #include <signal.h>
 
 namespace {
+const QString kStatsFeedMain = QStringLiteral("main");
+const QString kStatsFeedProxy = QStringLiteral("proxy");
+
+QString normalizedStatsFeedTag(const QString &feedTag)
+{
+    const QString normalized = feedTag.trimmed().toLower();
+    return normalized == kStatsFeedProxy ? kStatsFeedProxy : kStatsFeedMain;
+}
+
 void setTableItem(QTableWidget *table, int row, int column, const QString &text)
 {
     if (!table) {
@@ -65,6 +77,20 @@ QString stripAnsiSequences(const QString &input)
 bool isIgnorableLogLine(const QString &line)
 {
     return line.contains(QStringLiteral("No support for ANSI escape sequences"), Qt::CaseInsensitive);
+}
+bool isTransientProcessTelemetryLine(const QString &line)
+{
+    const QString normalized = line.trimmed().toLower();
+    if (normalized.startsWith(QStringLiteral("frame type:"))) {
+        return true;
+    }
+    const bool sizePrefix = normalized.startsWith(QStringLiteral("size:"))
+                            || normalized.startsWith(QStringLiteral("size="));
+    const bool hasDuration = normalized.contains(QStringLiteral("duration:"))
+                             || normalized.contains(QStringLiteral("time="));
+    const bool hasBitrate = normalized.contains(QStringLiteral("bitrate:"))
+                            || normalized.contains(QStringLiteral("bitrate="));
+    return sizePrefix && hasDuration && hasBitrate;
 }
 QString quoteArgument(const QString &arg)
 {
@@ -171,6 +197,48 @@ QString runDirectoryDialog(QWidget *parent,
         return QString();
     }
     return dialog.selectedFiles().constFirst();
+}
+QString normalizeAudioTrackPathInput(const QString &path)
+{
+    QString normalized = path.trimmed();
+    if (normalized.isEmpty()) {
+        return QString();
+    }
+
+    const QStringList lines =
+        normalized.split(QRegularExpression(QStringLiteral("[\\r\\n]+")), Qt::SkipEmptyParts);
+    if (!lines.isEmpty()) {
+        normalized = lines.constFirst().trimmed();
+    }
+    if (normalized.isEmpty()) {
+        return QString();
+    }
+
+    if (normalized.startsWith(QStringLiteral("file:"), Qt::CaseInsensitive)) {
+        const QUrl parsedUrl = QUrl::fromUserInput(normalized);
+        if (parsedUrl.isValid() && parsedUrl.isLocalFile()) {
+            const QString localPath = parsedUrl.toLocalFile();
+            if (!localPath.isEmpty()) {
+                normalized = localPath;
+            }
+        }
+    }
+
+    normalized = QDir::cleanPath(QDir::fromNativeSeparators(normalized));
+    return QDir::toNativeSeparators(normalized);
+}
+
+void normalizeAudioTrackLineEditPath(QLineEdit *lineEdit)
+{
+    if (!lineEdit) {
+        return;
+    }
+    const QString normalized = normalizeAudioTrackPathInput(lineEdit->text());
+    if (normalized == lineEdit->text()) {
+        return;
+    }
+    const QSignalBlocker blocker(lineEdit);
+    lineEdit->setText(normalized);
 }
 
 QStringList defaultExecutableSearchDirs(const QString &currentInputFile)
@@ -309,6 +377,7 @@ struct ActiveAreaFrameDefaults {
     int ffrl = 0;
     int lfrl = 0;
 };
+constexpr int kVerticalFramingAutoUserDefinedThreshold = 20;
 
 ActiveAreaFrameDefaults activeAreaDefaultsForSystem(int system)
 {
@@ -330,18 +399,29 @@ bool hasExplicitVerticalFraming(const LdDecodeMetaData::VideoParameters &videoPa
            && videoParameters.firstActiveFrameLine > 0
            && videoParameters.lastActiveFrameLine > 0;
 }
-
-bool usesCustomVerticalFraming(const LdDecodeMetaData::VideoParameters &videoParameters)
+bool hasVerticalFramingDeltaBeyondThreshold(const LdDecodeMetaData::VideoParameters &videoParameters,
+                                            int thresholdLines)
 {
     if (!videoParameters.isValid || !hasExplicitVerticalFraming(videoParameters)) {
         return false;
     }
 
     const ActiveAreaFrameDefaults defaults = activeAreaDefaultsForSystem(videoParameters.system);
-    return videoParameters.firstActiveFieldLine != defaults.ffll
-           || videoParameters.lastActiveFieldLine != defaults.lfll
-           || videoParameters.firstActiveFrameLine != defaults.ffrl
-           || videoParameters.lastActiveFrameLine != defaults.lfrl;
+    const int clampedThreshold = qMax(0, thresholdLines);
+    const auto exceedsThreshold = [clampedThreshold](int value, int defaultValue) {
+        return value > 0 && qAbs(value - defaultValue) > clampedThreshold;
+    };
+
+    return exceedsThreshold(videoParameters.firstActiveFieldLine, defaults.ffll)
+           || exceedsThreshold(videoParameters.lastActiveFieldLine, defaults.lfll)
+           || exceedsThreshold(videoParameters.firstActiveFrameLine, defaults.ffrl)
+           || exceedsThreshold(videoParameters.lastActiveFrameLine, defaults.lfrl);
+}
+
+bool usesCustomVerticalFraming(const LdDecodeMetaData::VideoParameters &videoParameters)
+{
+    return hasVerticalFramingDeltaBeyondThreshold(videoParameters,
+                                                  kVerticalFramingAutoUserDefinedThreshold);
 }
 
 bool hasAnyNonDefaultVerticalFraming(const LdDecodeMetaData::VideoParameters &videoParameters)
@@ -1351,6 +1431,14 @@ ExportDialog::ExportDialog(QWidget *parent) :
     if (ui->generateProxyCheckBox) {
         ui->generateProxyCheckBox->setChecked(false);
         connect(ui->generateProxyCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+            if ((!exportProcess || exportProcess->state() == QProcess::NotRunning)
+                && (!parallelProxyProcess || parallelProxyProcess->state() == QProcess::NotRunning)) {
+                splitStatsByFeed = checked;
+                updateProcessStatsPaneMode();
+                updateFeedLogPaneMode();
+                resetProcessStats();
+                initializeProcessStats();
+            }
             updateProfileDependentControls();
             emit proxyGenerationPreferenceChanged(checked);
         });
@@ -1507,9 +1595,13 @@ ExportDialog::ExportDialog(QWidget *parent) :
         });
     }
     updateRangeLengthLabel();
-    if (ui->processStatsTable) {
-        ui->processStatsTable->setColumnCount(7);
-        ui->processStatsTable->setHorizontalHeaderLabels({
+    mainProcessStatsTable = ui->processStatsTable;
+    const auto configureProcessStatsTable = [this](QTableWidget *table, const QString &toolTip) {
+        if (!table) {
+            return;
+        }
+        table->setColumnCount(7);
+        table->setHorizontalHeaderLabels({
             tr("Process"),
             tr("TBC"),
             tr("Track"),
@@ -1518,19 +1610,83 @@ ExportDialog::ExportDialog(QWidget *parent) :
             tr("Errors"),
             tr("FPS")
         });
-        ui->processStatsTable->verticalHeader()->setVisible(false);
-        ui->processStatsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
-        ui->processStatsTable->setSelectionMode(QAbstractItemView::NoSelection);
-        ui->processStatsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
-        ui->processStatsTable->setAlternatingRowColors(true);
-        ui->processStatsTable->horizontalHeader()->setStretchLastSection(true);
-        ui->processStatsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-        ui->processStatsTable->setMinimumHeight(90);
+        table->verticalHeader()->setVisible(false);
+        table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        table->setSelectionMode(QAbstractItemView::NoSelection);
+        table->setSelectionBehavior(QAbstractItemView::SelectRows);
+        table->setAlternatingRowColors(true);
+        table->horizontalHeader()->setStretchLastSection(true);
+        table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+        table->setMinimumHeight(110);
+        table->setToolTip(toolTip);
+        table->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    };
+    configureProcessStatsTable(mainProcessStatsTable, tr("Main export process stats"));
+    if (mainProcessStatsTable && ui->mainLayout) {
+        const int processStatsIndex = ui->mainLayout->indexOf(mainProcessStatsTable);
+        processStatsSplitter = new QSplitter(Qt::Horizontal, this);
+        processStatsSplitter->setObjectName(QStringLiteral("processStatsSplitter"));
+        processStatsSplitter->setChildrenCollapsible(false);
+        processStatsSplitter->setHandleWidth(2);
+        processStatsSplitter->setMinimumHeight(110);
+        processStatsSplitter->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+        proxyProcessStatsTable = new QTableWidget(processStatsSplitter);
+        proxyProcessStatsTable->setObjectName(QStringLiteral("proxyProcessStatsTable"));
+        configureProcessStatsTable(proxyProcessStatsTable, tr("Proxy export process stats"));
+
+        ui->mainLayout->removeWidget(mainProcessStatsTable);
+        mainProcessStatsTable->setParent(processStatsSplitter);
+        processStatsSplitter->addWidget(mainProcessStatsTable);
+        processStatsSplitter->addWidget(proxyProcessStatsTable);
+        processStatsSplitter->setStretchFactor(0, 1);
+        processStatsSplitter->setStretchFactor(1, 1);
+        processStatsSplitter->setSizes(QList<int>({1, 1}));
+
+        if (processStatsIndex >= 0) {
+            ui->mainLayout->insertWidget(processStatsIndex, processStatsSplitter);
+        } else {
+            ui->mainLayout->addWidget(processStatsSplitter);
+        }
     }
+    updateProcessStatsPaneMode();
     if (ui->logTextEdit) {
-        ui->logTextEdit->setMaximumBlockCount(3);
-        const int lineHeight = QFontMetrics(ui->logTextEdit->font()).lineSpacing();
-        ui->logTextEdit->setFixedHeight(lineHeight * 3 + 8);
+        ui->logTextEdit->setMaximumBlockCount(10);
+        ui->logTextEdit->setPlaceholderText(tr("Main export feed"));
+        ui->logTextEdit->setLineWrapMode(QPlainTextEdit::NoWrap);
+        ui->logTextEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        if (ui->proxyLogTextEdit) {
+            ui->proxyLogTextEdit->setMaximumBlockCount(10);
+            ui->proxyLogTextEdit->setPlaceholderText(tr("Proxy export feed"));
+            ui->proxyLogTextEdit->setLineWrapMode(QPlainTextEdit::NoWrap);
+            ui->proxyLogTextEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        }
+        if (ui->feedLogSplitter) {
+            ui->feedLogSplitter->setChildrenCollapsible(false);
+            ui->feedLogSplitter->setHandleWidth(2);
+            ui->feedLogSplitter->setStretchFactor(0, 1);
+            ui->feedLogSplitter->setStretchFactor(1, 1);
+            ui->feedLogSplitter->setSizes(QList<int>({1, 1}));
+            ui->feedLogSplitter->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        }
+        updateFeedLogPaneSizing();
+    }
+    if (ui->mainLayout) {
+        QWidget *statsWidget = processStatsSplitter
+                                   ? static_cast<QWidget *>(processStatsSplitter)
+                                   : static_cast<QWidget *>(mainProcessStatsTable);
+        if (statsWidget) {
+            const int statsIndex = ui->mainLayout->indexOf(statsWidget);
+            if (statsIndex >= 0) {
+                ui->mainLayout->setStretch(statsIndex, 2);
+            }
+        }
+        if (ui->feedLogSplitter) {
+            const int feedIndex = ui->mainLayout->indexOf(ui->feedLogSplitter);
+            if (feedIndex >= 0) {
+                ui->mainLayout->setStretch(feedIndex, 3);
+            }
+        }
     }
     if (ui->cancelButton) {
         ui->cancelButton->setEnabled(false);
@@ -1541,6 +1697,28 @@ ExportDialog::ExportDialog(QWidget *parent) :
     if (ui->profileComboBox) {
         connect(ui->profileComboBox, &QComboBox::currentTextChanged, this,
                 [this](const QString &) { updateProfileDependentControls(); });
+    }
+    const QList<QLineEdit *> audioTrackLineEdits = {
+        ui->audio1LineEdit,
+        ui->audio2LineEdit,
+        ui->audio3LineEdit,
+        ui->audio4LineEdit
+    };
+    for (QLineEdit *audioTrackLineEdit : audioTrackLineEdits) {
+        if (!audioTrackLineEdit) {
+            continue;
+        }
+        connect(audioTrackLineEdit, &QLineEdit::textChanged, this, [audioTrackLineEdit](const QString &text) {
+            if (!text.contains(QStringLiteral("file://"), Qt::CaseInsensitive)
+                && !text.contains(QLatin1Char('\r'))
+                && !text.contains(QLatin1Char('\n'))) {
+                return;
+            }
+            normalizeAudioTrackLineEditPath(audioTrackLineEdit);
+        });
+        connect(audioTrackLineEdit, &QLineEdit::editingFinished, this, [audioTrackLineEdit]() {
+            normalizeAudioTrackLineEditPath(audioTrackLineEdit);
+        });
     }
     if (ui->proresVariantComboBox) {
         connect(ui->proresVariantComboBox, &QComboBox::currentTextChanged, this,
@@ -1582,6 +1760,9 @@ ExportDialog::ExportDialog(QWidget *parent) :
     connect(parallelProxyProcess, &QProcess::started, this, [this]() {
         appendLog(tr("Parallel proxy export started (PID %1).").arg(parallelProxyProcess->processId()));
     });
+    splitStatsByFeed = shouldGenerateProxyForSelection();
+    updateProcessStatsPaneMode();
+    updateFeedLogPaneMode();
     updateProfileDependentControls();
 
     appendStatus(tr("Ready."));
@@ -1592,6 +1773,105 @@ ExportDialog::~ExportDialog()
 {
     cleanupTemporaryMetadataSnapshot();
     delete ui;
+}
+
+void ExportDialog::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    updateFeedLogPaneSizing();
+}
+void ExportDialog::updateFeedLogPaneMode()
+{
+    if (!ui || !ui->logTextEdit) {
+        return;
+    }
+
+    const bool splitFeedLogs = splitStatsByFeed && ui->proxyLogTextEdit;
+    ui->logTextEdit->setVisible(true);
+    if (ui->proxyLogTextEdit) {
+        ui->proxyLogTextEdit->setVisible(splitFeedLogs);
+    }
+    if (!ui->feedLogSplitter) {
+        return;
+    }
+    ui->feedLogSplitter->setHandleWidth(splitFeedLogs ? 2 : 0);
+    if (splitFeedLogs) {
+        ui->feedLogSplitter->setSizes(QList<int>({1, 1}));
+    } else {
+        ui->feedLogSplitter->setSizes(QList<int>({1, 0}));
+    }
+}
+
+void ExportDialog::updateFeedLogPaneSizing()
+{
+    if (!ui || !ui->logTextEdit) {
+        return;
+    }
+
+    const int lineHeight = QFontMetrics(ui->logTextEdit->font()).lineSpacing();
+    const int baseVisibleLines = 8;
+    const int basePadding = 10;
+    const int dynamicExtraPx = qBound(20, height() / 12, 220);
+    const int logHeight = (lineHeight * baseVisibleLines) + basePadding + dynamicExtraPx;
+    const int dynamicVisibleLines = qMax(baseVisibleLines, (logHeight - basePadding) / qMax(1, lineHeight));
+    const int maxLogBlocks = qMax(60, dynamicVisibleLines * 12);
+    if (ui->logTextEdit->minimumHeight() != logHeight) {
+        ui->logTextEdit->setMinimumHeight(logHeight);
+    }
+    if (ui->logTextEdit->maximumBlockCount() != maxLogBlocks) {
+        ui->logTextEdit->setMaximumBlockCount(maxLogBlocks);
+    }
+    if (ui->proxyLogTextEdit && ui->proxyLogTextEdit->minimumHeight() != logHeight) {
+        ui->proxyLogTextEdit->setMinimumHeight(logHeight);
+    }
+    if (ui->proxyLogTextEdit && ui->proxyLogTextEdit->maximumBlockCount() != maxLogBlocks) {
+        ui->proxyLogTextEdit->setMaximumBlockCount(maxLogBlocks);
+    }
+    if (ui->feedLogSplitter && ui->feedLogSplitter->minimumHeight() != logHeight) {
+        ui->feedLogSplitter->setMinimumHeight(logHeight);
+    }
+}
+void ExportDialog::updateProcessStatsPaneMode()
+{
+    if (!mainProcessStatsTable && ui) {
+        mainProcessStatsTable = ui->processStatsTable;
+    }
+    if (!mainProcessStatsTable) {
+        return;
+    }
+
+    if (!processStatsSplitter) {
+        if (proxyProcessStatsTable) {
+            proxyProcessStatsTable->setVisible(splitStatsByFeed);
+        }
+        return;
+    }
+
+    mainProcessStatsTable->setVisible(true);
+    if (proxyProcessStatsTable) {
+        proxyProcessStatsTable->setVisible(splitStatsByFeed);
+    }
+
+    processStatsSplitter->setHandleWidth(splitStatsByFeed ? 2 : 0);
+    if (splitStatsByFeed) {
+        processStatsSplitter->setSizes(QList<int>({1, 1}));
+    } else {
+        processStatsSplitter->setSizes(QList<int>({1, 0}));
+    }
+}
+
+QTableWidget *ExportDialog::processStatsTableForFeed(const QString &feedTag) const
+{
+    const QString normalizedFeedTag = normalizedStatsFeedTag(feedTag);
+    if (splitStatsByFeed
+        && normalizedFeedTag == kStatsFeedProxy
+        && proxyProcessStatsTable) {
+        return proxyProcessStatsTable;
+    }
+    if (mainProcessStatsTable) {
+        return mainProcessStatsTable;
+    }
+    return ui ? ui->processStatsTable : nullptr;
 }
 
 void ExportDialog::setSource(TbcSource *source)
@@ -1610,6 +1890,14 @@ void ExportDialog::setGenerateProxyEnabledPreference(bool enabled)
 
     const QSignalBlocker blocker(ui->generateProxyCheckBox);
     ui->generateProxyCheckBox->setChecked(enabled);
+    if ((!exportProcess || exportProcess->state() == QProcess::NotRunning)
+        && (!parallelProxyProcess || parallelProxyProcess->state() == QProcess::NotRunning)) {
+        splitStatsByFeed = enabled;
+        updateProcessStatsPaneMode();
+        updateFeedLogPaneMode();
+        resetProcessStats();
+        initializeProcessStats();
+    }
     updateProfileDependentControls();
 }
 
@@ -1745,7 +2033,7 @@ void ExportDialog::loadAudioTracksForExport(const QStringList &trackFiles, const
 
     int loadedTrackCount = 0;
     for (const QString &trackFileValue : trackFiles) {
-        const QString trackFile = trackFileValue.trimmed();
+        const QString trackFile = normalizeAudioTrackPathInput(trackFileValue);
         if (trackFile.isEmpty()) {
             continue;
         }
@@ -2765,8 +3053,12 @@ void ExportDialog::on_exportButton_clicked()
         const bool supportsAppendVideoFilter = executableSupportsOption(exportPath, QStringLiteral("--append-video-filter"));
         const bool supportsD1OutputSizing = executableSupportsD1OutputSizing(exportPath);
         const LdDecodeMetaData::VideoParameters &previewVideoParameters = tbcSource->getVideoParameters();
-        const bool hasCustomActiveLineFraming = resolutionMode == QStringLiteral("user_defined")
-                                                || hasAnyNonDefaultVerticalFraming(previewVideoParameters);
+        const bool hasAnyVerticalLineAdjustment = hasAnyNonDefaultVerticalFraming(previewVideoParameters);
+        const bool hasSignificantVerticalLineAdjustment =
+            hasVerticalFramingDeltaBeyondThreshold(previewVideoParameters,
+                                                   kVerticalFramingAutoUserDefinedThreshold);
+    const bool hasCustomActiveLineFraming = resolutionMode == QStringLiteral("user_defined")
+                                            || hasSignificantVerticalLineAdjustment;
         const bool deinterlacedOutputProfile = isWebProfileName(selectedProfile);
         if (dropoutMode == QStringLiteral("heavy")
             && !executableSupportsOption(exportPath, QStringLiteral("--overcorrect"))) {
@@ -3070,6 +3362,18 @@ void ExportDialog::on_exportButton_clicked()
     outputBaseForCurrentRun = outputBase;
     proxyCodecForCurrentRun = selectedProxyCodec;
     proxyOutputPathForCurrentRun = plannedProxyOutputPath;
+    splitStatsByFeed = generateProxyRequested;
+    updateProcessStatsPaneMode();
+    updateFeedLogPaneMode();
+    clearFeedLogLines();
+    if (splitStatsByFeed && ui) {
+        if (ui->logTextEdit) {
+            ui->logTextEdit->clear();
+        }
+        if (ui->proxyLogTextEdit) {
+            ui->proxyLogTextEdit->clear();
+        }
+    }
     resetProcessStats();
     initializeProcessStats();
 
@@ -3228,8 +3532,9 @@ void ExportDialog::on_cancelButton_clicked()
 
 void ExportDialog::handleProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    flushPendingProcessOutput();
     const RunStage finishedStage = activeRunStage;
+    const QString feedTag = finishedStage == RunStage::ProxyExport ? kStatsFeedProxy : kStatsFeedMain;
+    flushPendingProcessOutput(feedTag);
     const bool wasCancelRequested = cancelRequested;
     cancelRequested = false;
     const QString combinedOutput = processStdout + QStringLiteral("\n") + processStderr;
@@ -3346,8 +3651,9 @@ void ExportDialog::handleProcessFinished(int exitCode, QProcess::ExitStatus exit
 void ExportDialog::handleProcessError(QProcess::ProcessError)
 {
     setBusy(false);
-    flushPendingProcessOutput();
     const RunStage failedStage = activeRunStage;
+    const QString feedTag = failedStage == RunStage::ProxyExport ? kStatsFeedProxy : kStatsFeedMain;
+    flushPendingProcessOutput(feedTag);
     const QString errorText = exportProcess ? exportProcess->errorString() : QString();
     if (failedStage != RunStage::ProxyExport
         && parallelProxyProcess
@@ -3393,7 +3699,7 @@ void ExportDialog::handleProcessError(QProcess::ProcessError)
     }
     clearRunState();
 }
-void ExportDialog::processOutputLine(const QString &line, QString *lastStatus)
+void ExportDialog::processOutputLine(const QString &line, QString *lastStatus, const QString &feedTag)
 {
     const QString trimmed = line.trimmed();
     if (trimmed.isEmpty() || isIgnorableLogLine(trimmed)) {
@@ -3402,6 +3708,7 @@ void ExportDialog::processOutputLine(const QString &line, QString *lastStatus)
 
     ExportProcessStat stat;
     if (parseProgressLine(trimmed, &stat)) {
+        stat.feedTag = feedTag;
         updateProcessStat(stat);
         return;
     }
@@ -3409,10 +3716,17 @@ void ExportDialog::processOutputLine(const QString &line, QString *lastStatus)
     if (lastStatus) {
         *lastStatus = trimmed;
     }
+    if (splitStatsByFeed) {
+        if (isTransientProcessTelemetryLine(trimmed)) {
+            return;
+        }
+        appendFeedLog(trimmed, feedTag);
+        return;
+    }
     appendLog(trimmed);
 }
 
-void ExportDialog::consumeProcessOutputChunk(const QString &chunk, QString *pendingBuffer)
+void ExportDialog::consumeProcessOutputChunk(const QString &chunk, QString *pendingBuffer, const QString &feedTag)
 {
     if (!pendingBuffer || chunk.isEmpty()) {
         return;
@@ -3421,6 +3735,7 @@ void ExportDialog::consumeProcessOutputChunk(const QString &chunk, QString *pend
     QString buffer = *pendingBuffer + stripAnsiSequences(chunk);
     ExportProcessStat ffmpegStat;
     if (parseFfmpegProgressLine(buffer, &ffmpegStat)) {
+        ffmpegStat.feedTag = feedTag;
         updateProcessStat(ffmpegStat);
     }
     buffer.replace(QLatin1Char('\r'), QLatin1Char('\n'));
@@ -3440,17 +3755,17 @@ void ExportDialog::consumeProcessOutputChunk(const QString &chunk, QString *pend
     QString lastStatus;
     const QStringList lines = completeLines.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
     for (const QString &line : lines) {
-        processOutputLine(line, &lastStatus);
+        processOutputLine(line, &lastStatus, feedTag);
     }
     if (!lastStatus.isEmpty()) {
-        appendStatus(lastStatus);
+        appendFeedStatus(lastStatus, feedTag);
     }
 }
 
-void ExportDialog::flushPendingProcessOutput()
+void ExportDialog::flushPendingProcessOutput(const QString &feedTag)
 {
-    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingStdoutBuffer);
-    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingStderrBuffer);
+    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingStdoutBuffer, feedTag);
+    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingStderrBuffer, feedTag);
     pendingStdoutBuffer.clear();
     pendingStderrBuffer.clear();
 }
@@ -3459,34 +3774,36 @@ void ExportDialog::handleProcessStdout()
 {
     const QString chunk = QString::fromLocal8Bit(exportProcess->readAllStandardOutput());
     processStdout += chunk;
-    consumeProcessOutputChunk(chunk, &pendingStdoutBuffer);
+    const QString feedTag = activeRunStage == RunStage::ProxyExport ? kStatsFeedProxy : kStatsFeedMain;
+    consumeProcessOutputChunk(chunk, &pendingStdoutBuffer, feedTag);
 }
 
 void ExportDialog::handleProcessStderr()
 {
     const QString chunk = QString::fromLocal8Bit(exportProcess->readAllStandardError());
     processStderr += chunk;
-    consumeProcessOutputChunk(chunk, &pendingStderrBuffer);
+    const QString feedTag = activeRunStage == RunStage::ProxyExport ? kStatsFeedProxy : kStatsFeedMain;
+    consumeProcessOutputChunk(chunk, &pendingStderrBuffer, feedTag);
 }
 
 void ExportDialog::handleParallelProxyProcessStdout()
 {
     const QString chunk = QString::fromLocal8Bit(parallelProxyProcess->readAllStandardOutput());
     parallelProxyStdout += chunk;
-    consumeProcessOutputChunk(chunk, &pendingParallelProxyStdoutBuffer);
+    consumeProcessOutputChunk(chunk, &pendingParallelProxyStdoutBuffer, kStatsFeedProxy);
 }
 
 void ExportDialog::handleParallelProxyProcessStderr()
 {
     const QString chunk = QString::fromLocal8Bit(parallelProxyProcess->readAllStandardError());
     parallelProxyStderr += chunk;
-    consumeProcessOutputChunk(chunk, &pendingParallelProxyStderrBuffer);
+    consumeProcessOutputChunk(chunk, &pendingParallelProxyStderrBuffer, kStatsFeedProxy);
 }
 
 void ExportDialog::handleParallelProxyProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingParallelProxyStdoutBuffer);
-    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingParallelProxyStderrBuffer);
+    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingParallelProxyStdoutBuffer, kStatsFeedProxy);
+    consumeProcessOutputChunk(QStringLiteral("\n"), &pendingParallelProxyStderrBuffer, kStatsFeedProxy);
     pendingParallelProxyStdoutBuffer.clear();
     pendingParallelProxyStderrBuffer.clear();
 
@@ -3587,20 +3904,26 @@ void ExportDialog::handleParallelProxyProcessError(QProcess::ProcessError)
 void ExportDialog::resetProcessStats()
 {
     processRowMap.clear();
-    if (ui->processStatsTable) {
-        ui->processStatsTable->setRowCount(0);
+    if (mainProcessStatsTable) {
+        mainProcessStatsTable->setRowCount(0);
+    }
+    if (proxyProcessStatsTable) {
+        proxyProcessStatsTable->setRowCount(0);
     }
 }
 
 void ExportDialog::initializeProcessStats()
 {
-    if (!tbcSource || !ui->processStatsTable) {
+    if (!tbcSource || !mainProcessStatsTable) {
         return;
     }
 
     const int totalFramesValue = qMax(0, tbcSource->getNumberOfFrames());
     const QString totalFrames = totalFramesValue > 0 ? QString::number(totalFramesValue) : QStringLiteral("—");
-    auto seedStat = [this, &totalFrames](const QString &process, const QString &tbcType) {
+    const TbcSource::SourceMode mode = tbcSource->getSourceMode();
+    const auto seedStat = [this, &totalFrames](const QString &process,
+                                               const QString &tbcType,
+                                               const QString &feedTag) {
         ExportProcessStat stat;
         stat.process = process;
         stat.tbcType = tbcType;
@@ -3609,69 +3932,55 @@ void ExportDialog::initializeProcessStats()
         stat.total = totalFrames;
         stat.errors = QStringLiteral("0");
         stat.fps = QStringLiteral("—");
+        stat.feedTag = feedTag;
         updateProcessStat(stat);
     };
-
-    const TbcSource::SourceMode mode = tbcSource->getSourceMode();
-    if (mode == TbcSource::BOTH_SOURCES) {
-        seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("LUMA"));
-        seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("CHROMA"));
-        seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("LUMA"));
-        seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("CHROMA"));
-    } else if (mode == TbcSource::LUMA_SOURCE) {
-        seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("LUMA"));
-        seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("LUMA"));
-    } else if (mode == TbcSource::CHROMA_SOURCE) {
-        seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("CHROMA"));
-        seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("CHROMA"));
-    } else {
-        seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("COMBINED"));
-        seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("COMBINED"));
+    const auto seedFeed = [&seedStat, mode](const QString &feedTag) {
+        if (mode == TbcSource::BOTH_SOURCES) {
+            seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("LUMA"), feedTag);
+            seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("CHROMA"), feedTag);
+            seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("LUMA"), feedTag);
+            seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("CHROMA"), feedTag);
+        } else if (mode == TbcSource::LUMA_SOURCE) {
+            seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("LUMA"), feedTag);
+            seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("LUMA"), feedTag);
+        } else if (mode == TbcSource::CHROMA_SOURCE) {
+            seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("CHROMA"), feedTag);
+            seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("CHROMA"), feedTag);
+        } else {
+            seedStat(QStringLiteral("ld-dropout-correct"), QStringLiteral("COMBINED"), feedTag);
+            seedStat(QStringLiteral("ld-chroma-decoder"), QStringLiteral("COMBINED"), feedTag);
+        }
+        seedStat(QStringLiteral("ffmpeg"), QStringLiteral("—"), feedTag);
+    };
+    seedFeed(kStatsFeedMain);
+    if (splitStatsByFeed) {
+        seedFeed(kStatsFeedProxy);
     }
-    seedStat(QStringLiteral("ffmpeg"), QStringLiteral("—"));
 }
 
 void ExportDialog::updateProcessStat(const ExportProcessStat &stat)
 {
-    if (!ui->processStatsTable) {
+    const QString feedTag = normalizedStatsFeedTag(stat.feedTag);
+    const QString keyFeed = splitStatsByFeed ? feedTag : kStatsFeedMain;
+    QTableWidget *targetTable = processStatsTableForFeed(keyFeed);
+    if (!targetTable) {
         return;
     }
-    if (stat.tbcType == QStringLiteral("—")) {
-        QVector<int> processRows;
-        processRows.reserve(ui->processStatsTable->rowCount());
-        for (int rowIndex = 0; rowIndex < ui->processStatsTable->rowCount(); ++rowIndex) {
-            QTableWidgetItem *processItem = ui->processStatsTable->item(rowIndex, 0);
-            if (processItem && processItem->text() == stat.process) {
-                processRows.push_back(rowIndex);
-            }
-        }
-        if (!processRows.isEmpty()) {
-            for (const int rowIndex : processRows) {
-                setTableItem(ui->processStatsTable, rowIndex, 0, stat.process);
-                setTableItem(ui->processStatsTable, rowIndex, 2, stat.trackedName);
-                setTableItem(ui->processStatsTable, rowIndex, 3, stat.current);
-                setTableItem(ui->processStatsTable, rowIndex, 4, stat.total);
-                setTableItem(ui->processStatsTable, rowIndex, 5, stat.errors);
-                setTableItem(ui->processStatsTable, rowIndex, 6, stat.fps);
-            }
-            return;
-        }
-    }
-    const QString key = stat.process + QStringLiteral("|") + stat.tbcType;
+    const QString key = keyFeed + QStringLiteral("|") + stat.process + QStringLiteral("|") + stat.tbcType;
     int row = processRowMap.value(key, -1);
-    if (row < 0) {
-        row = ui->processStatsTable->rowCount();
-        ui->processStatsTable->insertRow(row);
+    if (row < 0 || row >= targetTable->rowCount()) {
+        row = targetTable->rowCount();
+        targetTable->insertRow(row);
         processRowMap.insert(key, row);
     }
-
-    setTableItem(ui->processStatsTable, row, 0, stat.process);
-    setTableItem(ui->processStatsTable, row, 1, stat.tbcType);
-    setTableItem(ui->processStatsTable, row, 2, stat.trackedName);
-    setTableItem(ui->processStatsTable, row, 3, stat.current);
-    setTableItem(ui->processStatsTable, row, 4, stat.total);
-    setTableItem(ui->processStatsTable, row, 5, stat.errors);
-    setTableItem(ui->processStatsTable, row, 6, stat.fps);
+    setTableItem(targetTable, row, 0, stat.process);
+    setTableItem(targetTable, row, 1, stat.tbcType);
+    setTableItem(targetTable, row, 2, stat.trackedName);
+    setTableItem(targetTable, row, 3, stat.current);
+    setTableItem(targetTable, row, 4, stat.total);
+    setTableItem(targetTable, row, 5, stat.errors);
+    setTableItem(targetTable, row, 6, stat.fps);
 }
 
 void ExportDialog::setBusy(bool busy)
@@ -4043,10 +4352,10 @@ QStringList ExportDialog::collectAudioTracks() const
 {
     QStringList tracks;
     const QStringList candidates = {
-        ui->audio1LineEdit->text().trimmed(),
-        ui->audio2LineEdit->text().trimmed(),
-        ui->audio3LineEdit->text().trimmed(),
-        ui->audio4LineEdit->text().trimmed()
+        normalizeAudioTrackPathInput(ui->audio1LineEdit->text()),
+        normalizeAudioTrackPathInput(ui->audio2LineEdit->text()),
+        normalizeAudioTrackPathInput(ui->audio3LineEdit->text()),
+        normalizeAudioTrackPathInput(ui->audio4LineEdit->text())
     };
     for (const QString &track : candidates) {
         if (!track.isEmpty()) {
@@ -4329,6 +4638,9 @@ bool ExportDialog::startProxyExport(QString *errorMessage, bool forceOverwrite)
     }
 
     proxyOutputPathForCurrentRun = targetProxyPath;
+    splitStatsByFeed = true;
+    updateProcessStatsPaneMode();
+    updateFeedLogPaneMode();
     processStdout.clear();
     processStderr.clear();
     pendingStdoutBuffer.clear();
@@ -4347,6 +4659,7 @@ bool ExportDialog::startProxyExport(QString *errorMessage, bool forceOverwrite)
     stat.total = QStringLiteral("—");
     stat.errors = QStringLiteral("0");
     stat.fps = QStringLiteral("—");
+    stat.feedTag = kStatsFeedProxy;
     updateProcessStat(stat);
 
     exportProcess->setWorkingDirectory(QFileInfo(sourceVideoPath).absolutePath());
@@ -4392,6 +4705,11 @@ void ExportDialog::clearRunState()
     parallelProxyStderr.clear();
     pendingParallelProxyStdoutBuffer.clear();
     pendingParallelProxyStderrBuffer.clear();
+    clearFeedStatusLines();
+    clearFeedLogLines();
+    splitStatsByFeed = shouldGenerateProxyForSelection();
+    updateProcessStatsPaneMode();
+    updateFeedLogPaneMode();
     cleanupTemporaryMetadataSnapshot();
 }
 bool ExportDialog::prepareTrimmedAudioTracks(int zeroBasedStartFrame,
@@ -4464,7 +4782,7 @@ bool ExportDialog::prepareTrimmedAudioTracks(int zeroBasedStartFrame,
     QStringList trimmedTracks;
     trimmedTracks.reserve(audioTracks->size());
     for (int index = 0; index < audioTracks->size(); ++index) {
-        const QString sourceTrack = audioTracks->at(index).trimmed();
+        const QString sourceTrack = normalizeAudioTrackPathInput(audioTracks->at(index));
         if (sourceTrack.isEmpty()) {
             continue;
         }
@@ -4714,7 +5032,7 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
         appendTrackTitle(ui->audio4LineEdit, ui->audio4NameLineEdit);
     }
     for (int i = 0; i < tracksToUse.size(); ++i) {
-        const QString track = tracksToUse.at(i).trimmed();
+        const QString track = normalizeAudioTrackPathInput(tracksToUse.at(i));
         if (track.isEmpty()) {
             continue;
         }
@@ -4793,9 +5111,12 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
             args << QStringLiteral("--lfrl") << QString::number(lfrl);
         }
     };
-    const bool forwardActiveLines = hasAnyNonDefaultVerticalFraming(videoParameters);
+    const bool hasAnyVerticalLineAdjustment = hasAnyNonDefaultVerticalFraming(videoParameters);
+    const bool hasSignificantVerticalLineAdjustment =
+        hasVerticalFramingDeltaBeyondThreshold(videoParameters,
+                                               kVerticalFramingAutoUserDefinedThreshold);
     const bool hasCustomActiveLineFraming = resolutionMode == QStringLiteral("user_defined")
-                                            || forwardActiveLines;
+                                            || hasSignificantVerticalLineAdjustment;
     const bool letterboxCropRequested = ui->letterboxCropCheckBox
                                         && ui->letterboxCropCheckBox->isChecked();
     const bool forceAnamorphicRequested = ui->forceAnamorphicCheckBox
@@ -4864,7 +5185,7 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
         }
     } else if (resolutionMode == QStringLiteral("active_vbi")) {
         args << QStringLiteral("--vbi");
-    } else if (resolutionMode == QStringLiteral("user_defined") || forwardActiveLines) {
+    } else if (resolutionMode == QStringLiteral("user_defined") || hasAnyVerticalLineAdjustment) {
         appendFramingArgs(videoParameters.firstActiveFieldLine,
                           videoParameters.lastActiveFieldLine,
                           videoParameters.firstActiveFrameLine,
@@ -5315,6 +5636,74 @@ void ExportDialog::appendStatus(const QString &message)
 {
     ui->statusLabel->setText(message);
 }
+void ExportDialog::appendFeedStatus(const QString &message, const QString &feedTag)
+{
+    const QString trimmed = message.trimmed();
+    if (trimmed.isEmpty()) {
+        return;
+    }
+    if (!splitStatsByFeed) {
+        appendStatus(trimmed);
+        return;
+    }
+
+    const QString normalizedFeedTag = normalizedStatsFeedTag(feedTag);
+    if (normalizedFeedTag == kStatsFeedProxy) {
+        proxyFeedStatusLine = trimmed;
+    } else {
+        mainFeedStatusLine = trimmed;
+    }
+
+    const QString mainLine = mainFeedStatusLine.isEmpty() ? QStringLiteral("—") : mainFeedStatusLine;
+    const QString proxyLine = proxyFeedStatusLine.isEmpty() ? QStringLiteral("—") : proxyFeedStatusLine;
+    appendStatus(QStringLiteral("Main: %1\nProxy: %2").arg(mainLine, proxyLine));
+}
+
+void ExportDialog::clearFeedStatusLines()
+{
+    mainFeedStatusLine.clear();
+    proxyFeedStatusLine.clear();
+}
+
+void ExportDialog::appendFeedLog(const QString &message, const QString &feedTag)
+{
+    const QString trimmed = message.trimmed();
+    if (trimmed.isEmpty()) {
+        return;
+    }
+    if (!splitStatsByFeed || !ui || !ui->logTextEdit || !ui->proxyLogTextEdit) {
+        appendLog(trimmed);
+        return;
+    }
+
+    const QString normalizedFeedTag = normalizedStatsFeedTag(feedTag);
+    QString *lineTarget = normalizedFeedTag == kStatsFeedProxy ? &proxyFeedLogLine : &mainFeedLogLine;
+    QPlainTextEdit *targetLog = normalizedFeedTag == kStatsFeedProxy ? ui->proxyLogTextEdit : ui->logTextEdit;
+    if (*lineTarget == trimmed) {
+        return;
+    }
+    *lineTarget = trimmed;
+
+    const QString timestamp = QDateTime::currentDateTime().toString(QStringLiteral("HH:mm:ss"));
+    const QString rendered = QStringLiteral("[%1] %2").arg(timestamp, trimmed);
+    if (!rendered.isEmpty()) {
+        targetLog->appendPlainText(rendered);
+    }
+}
+
+void ExportDialog::clearFeedLogLines()
+{
+    mainFeedLogLine.clear();
+    proxyFeedLogLine.clear();
+    if (ui) {
+        if (ui->logTextEdit) {
+            ui->logTextEdit->clear();
+        }
+        if (ui->proxyLogTextEdit) {
+            ui->proxyLogTextEdit->clear();
+        }
+    }
+}
 
 void ExportDialog::appendLog(const QString &message)
 {
@@ -5393,8 +5782,16 @@ QString ExportDialog::writeExportFailureLog(const QString &failureTitle,
         const QString exportLog = ui->logTextEdit->toPlainText().trimmed();
         if (!exportLog.isEmpty()) {
             stream << '\n';
-            stream << "=== Export dialog log ===\n";
+            stream << "=== Main export dialog log ===\n";
             stream << exportLog << '\n';
+        }
+    }
+    if (ui && ui->proxyLogTextEdit) {
+        const QString proxyExportLog = ui->proxyLogTextEdit->toPlainText().trimmed();
+        if (!proxyExportLog.isEmpty()) {
+            stream << '\n';
+            stream << "=== Proxy export dialog log ===\n";
+            stream << proxyExportLog << '\n';
         }
     }
 

--- a/src/ld-analyse/exportdialog.h
+++ b/src/ld-analyse/exportdialog.h
@@ -38,6 +38,7 @@ public:
     void setExportProfileConfigPreference(bool enabled, const QString &configPath);
     void setInPoint(int frameNumber);
     void setOutPoint(int frameNumber);
+    bool hasAudioTracksConfigured() const;
     void loadAudioTracksForExport(const QStringList &trackFiles,
                                   const QStringList &trackNames = QStringList());
     void refreshResolutionOptions();

--- a/src/ld-analyse/exportdialog.h
+++ b/src/ld-analyse/exportdialog.h
@@ -6,6 +6,9 @@
 #include <QHash>
 
 class TbcSource;
+class QResizeEvent;
+class QSplitter;
+class QTableWidget;
 
 namespace Ui {
 class ExportDialog;
@@ -29,6 +32,7 @@ public:
         QString total;
         QString errors;
         QString fps;
+        QString feedTag;
     };
     explicit ExportDialog(QWidget *parent = nullptr);
     ~ExportDialog();
@@ -42,6 +46,8 @@ public:
     void loadAudioTracksForExport(const QStringList &trackFiles,
                                   const QStringList &trackNames = QStringList());
     void refreshResolutionOptions();
+protected:
+    void resizeEvent(QResizeEvent *event) override;
 signals:
     void userEditRangeSelectionChanged(int inPoint, int outPoint, bool clearMetadataValues);
     void proxyGenerationPreferenceChanged(bool enabled);
@@ -76,6 +82,8 @@ private:
     void updateFromSource();
     void refreshProfiles();
     void updateProfileDependentControls();
+    void updateFeedLogPaneMode();
+    void updateFeedLogPaneSizing();
     void emitRangeSelectionChanged(bool clearMetadataValues);
     void setBusy(bool busy);
     void updateRangeControlsForSource(bool resetToFullRange);
@@ -130,6 +138,10 @@ private:
     void updateExportProfileConfigPathUi();
     void emitExportProfileConfigPreferenceChanged();
     void appendStatus(const QString &message);
+    void appendFeedStatus(const QString &message, const QString &feedTag);
+    void clearFeedStatusLines();
+    void appendFeedLog(const QString &message, const QString &feedTag);
+    void clearFeedLogLines();
     void appendLog(const QString &message);
     QString writeExportFailureLog(const QString &failureTitle,
                                   const QString &summaryMessage,
@@ -141,10 +153,12 @@ private:
     QString formatCommand(const QString &program, const QStringList &args) const;
     void resetProcessStats();
     void initializeProcessStats();
+    void updateProcessStatsPaneMode();
+    QTableWidget *processStatsTableForFeed(const QString &feedTag) const;
     void updateProcessStat(const ExportProcessStat &stat);
-    void processOutputLine(const QString &line, QString *lastStatus);
-    void consumeProcessOutputChunk(const QString &chunk, QString *pendingBuffer);
-    void flushPendingProcessOutput();
+    void processOutputLine(const QString &line, QString *lastStatus, const QString &feedTag);
+    void consumeProcessOutputChunk(const QString &chunk, QString *pendingBuffer, const QString &feedTag);
+    void flushPendingProcessOutput(const QString &feedTag);
 
     Ui::ExportDialog *ui;
     TbcSource *tbcSource = nullptr;
@@ -177,6 +191,14 @@ private:
     bool parallelProxySucceeded = false;
     bool mainExportFinished = false;
     bool mainExportSucceeded = false;
+    bool splitStatsByFeed = false;
+    QString mainFeedStatusLine;
+    QString proxyFeedStatusLine;
+    QString mainFeedLogLine;
+    QString proxyFeedLogLine;
+    QSplitter *processStatsSplitter = nullptr;
+    QTableWidget *mainProcessStatsTable = nullptr;
+    QTableWidget *proxyProcessStatsTable = nullptr;
     QHash<QString, int> processRowMap;
 };
 

--- a/src/ld-analyse/exportdialog.ui
+++ b/src/ld-analyse/exportdialog.ui
@@ -720,19 +720,32 @@
     </widget>
    </item>
    <item>
-    <widget class="QPlainTextEdit" name="logTextEdit">
+    <widget class="QSplitter" name="feedLogSplitter">
      <property name="minimumSize">
       <size>
        <width>0</width>
        <height>54</height>
       </size>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="placeholderText">
-      <string>Export log</string>
-     </property>
+     <widget class="QPlainTextEdit" name="logTextEdit">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+      <property name="placeholderText">
+       <string>Main export feed</string>
+      </property>
+     </widget>
+     <widget class="QPlainTextEdit" name="proxyLogTextEdit">
+      <property name="readOnly">
+       <bool>true</bool>
+      </property>
+      <property name="placeholderText">
+       <string>Proxy export feed</string>
+      </property>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -127,6 +127,77 @@ QString sanitizedFileToken(const QString &value)
     return token;
 }
 
+struct EfmAutoloadCandidates {
+    QStringList efmInputs;
+    QStringList pcmInputs;
+    QString ac3Input;
+};
+
+EfmAutoloadCandidates discoverEfmAutoloadCandidates(const QString &directoryPath,
+                                                    const QString &sourceBaseName)
+{
+    EfmAutoloadCandidates candidates;
+    const QString normalizedDirectory = QDir::cleanPath(directoryPath.trimmed());
+    if (normalizedDirectory.isEmpty()) {
+        return candidates;
+    }
+
+    const QDir directory(normalizedDirectory);
+    if (!directory.exists()) {
+        return candidates;
+    }
+
+    const QFileInfoList entries = directory.entryInfoList(QDir::Files | QDir::NoSymLinks,
+                                                           QDir::Name | QDir::IgnoreCase);
+    const QString sourceBaseToken = sourceBaseName.trimmed().toLower();
+    QString bestAc3Candidate;
+    int bestAc3Score = -1;
+
+    for (const QFileInfo &entry : entries) {
+        const QString suffix = entry.suffix().toLower();
+        const QString fileNameLower = entry.fileName().toLower();
+        const QString absolutePath = entry.absoluteFilePath();
+
+        if (suffix == QStringLiteral("efm")) {
+            candidates.efmInputs << absolutePath;
+        }
+        if (suffix == QStringLiteral("pcm")) {
+            candidates.pcmInputs << absolutePath;
+        }
+
+        if (!fileNameLower.contains(QStringLiteral("ac3"))) {
+            continue;
+        }
+
+        int score = 0;
+        if (!sourceBaseToken.isEmpty() && fileNameLower.contains(sourceBaseToken)) {
+            score += 2;
+        }
+        if (suffix == QStringLiteral("bin")
+            || suffix == QStringLiteral("dat")
+            || suffix == QStringLiteral("txt")
+            || suffix == QStringLiteral("sym")
+            || suffix == QStringLiteral("symbols")
+            || suffix == QStringLiteral("raw")) {
+            score += 4;
+        } else if (suffix == QStringLiteral("ac3")) {
+            score += 1;
+        }
+        if (fileNameLower.contains(QStringLiteral("symbol"))
+            || fileNameLower.contains(QStringLiteral("sym"))) {
+            score += 3;
+        }
+
+        if (score > bestAc3Score) {
+            bestAc3Score = score;
+            bestAc3Candidate = absolutePath;
+        }
+    }
+
+    candidates.ac3Input = bestAc3Candidate;
+    return candidates;
+}
+
 void ensureSvgButtonIcon(QAbstractButton *button, const QString &resourcePath)
 {
     if (!button) {
@@ -2387,6 +2458,48 @@ QString MainWindow::outputBaseNameForCurrentSource()
     return sanitizedFileToken(baseName);
 }
 
+void MainWindow::applyEfmHandlerAutoloads(const QString &directoryPath)
+{
+    if (!efmHandlerDialog) {
+        return;
+    }
+
+    const QString normalizedDirectory = QDir::cleanPath(directoryPath.trimmed());
+    const QFileInfo directoryInfo(normalizedDirectory);
+    if (normalizedDirectory.isEmpty() || !directoryInfo.exists() || !directoryInfo.isDir()) {
+        return;
+    }
+
+    QString sourceBaseName;
+    const QString sourceFilename = tbcSource.getCurrentSourceFilename();
+    if (!sourceFilename.isEmpty()) {
+        sourceBaseName = QFileInfo(sourceFilename).completeBaseName();
+    } else if (!lastFilename.isEmpty()) {
+        sourceBaseName = QFileInfo(lastFilename).completeBaseName();
+    }
+
+    const EfmAutoloadCandidates candidates =
+        discoverEfmAutoloadCandidates(normalizedDirectory, sourceBaseName);
+    for (const QString &efmInput : candidates.efmInputs) {
+        efmHandlerDialog->setDefaultEfmInput(efmInput);
+    }
+    if (!candidates.ac3Input.isEmpty()) {
+        efmHandlerDialog->setDefaultAc3Input(candidates.ac3Input);
+    }
+
+    if (exportDialog
+        && !candidates.pcmInputs.isEmpty()
+        && !exportDialog->hasAudioTracksConfigured()) {
+        const QStringList trackFiles = candidates.pcmInputs.mid(0, 4);
+        QStringList trackNames;
+        trackNames.reserve(trackFiles.size());
+        for (const QString &trackFile : trackFiles) {
+            trackNames << QFileInfo(trackFile).completeBaseName();
+        }
+        exportDialog->loadAudioTracksForExport(trackFiles, trackNames);
+    }
+}
+
 // Redraw the viewer (for example, when scaleFactor has been changed)
 void MainWindow::updateImageViewer()
 {
@@ -4443,6 +4556,7 @@ void MainWindow::on_actionEFM_Handler_triggered()
     if (!suggestedOutputBase.isEmpty()) {
         efmHandlerDialog->setSuggestedOutputBase(suggestedOutputBase);
     }
+    applyEfmHandlerAutoloads(sourceDirectory);
 
     efmHandlerDialog->show();
     if (efmHandlerDialog->windowHandle() && windowHandle()) {
@@ -6182,6 +6296,7 @@ void MainWindow::on_finishedLoading(bool success)
         configuration.setSourceDirectory(inFileInfo.absolutePath());
         tbcDebugStream() << "MainWindow::loadTbcFile(): Setting source directory to:" << inFileInfo.absolutePath();
         configuration.writeConfiguration();
+        applyEfmHandlerAutoloads(inFileInfo.absolutePath());
     } else {
         // Load failed
         updateGuiUnloaded();

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -72,6 +72,7 @@
 #include "metadataconverterutil.h"
 #include "notesviewerdialog.h"
 #include "timelinemarkerslider.h"
+#include "efmhandlerdialog.h"
 #include "../audio-align/audioalignmentdialog.h"
 #include "../tbc-export-metadata/metadataexportdialog.h"
 #include "../ld-process-vits/processingpool.h"
@@ -4382,6 +4383,75 @@ void MainWindow::on_actionAuto_Audio_Align_triggered()
     }
 }
 
+void MainWindow::on_actionEFM_Handler_triggered()
+{
+    if (!efmHandlerDialog) {
+        efmHandlerDialog = new EfmHandlerDialog(this);
+        efmHandlerDialog->setModal(false);
+        efmHandlerDialog->setWindowModality(Qt::NonModal);
+        efmHandlerDialog->setWindowFlags(Qt::Window
+                                         | Qt::CustomizeWindowHint
+                                         | Qt::WindowTitleHint
+                                         | Qt::WindowSystemMenuHint
+                                         | Qt::WindowMinimizeButtonHint
+                                         | Qt::WindowCloseButtonHint);
+        efmHandlerDialog->setAttribute(Qt::WA_TranslucentBackground, false);
+        efmHandlerDialog->setAttribute(Qt::WA_NoSystemBackground, false);
+        efmHandlerDialog->setAutoFillBackground(true);
+        efmHandlerDialog->setWindowOpacity(1.0);
+        connect(efmHandlerDialog, &QObject::destroyed, this, [this]() {
+            efmHandlerDialog = nullptr;
+        });
+        connect(efmHandlerDialog, &EfmHandlerDialog::exportTracksPrepared, this,
+                [this](const QStringList &trackFiles, const QStringList &trackNames) {
+                    if (!exportDialog || trackFiles.isEmpty()) {
+                        return;
+                    }
+                    exportDialog->loadAudioTracksForExport(trackFiles, trackNames);
+                    if (ui && ui->mainTabWidget) {
+                        ui->mainTabWidget->setCurrentWidget(exportDialog);
+                    }
+                    statusBar()->showMessage(tr("Loaded %1 decoded EFM audio track(s) into Export.")
+                                                 .arg(trackFiles.size()),
+                                             5000);
+                });
+    }
+
+    efmHandlerDialog->setModal(false);
+    efmHandlerDialog->setWindowModality(Qt::NonModal);
+    efmHandlerDialog->setWindowOpacity(1.0);
+
+    QString sourceDirectory = outputRootDirectoryForCurrentSource();
+    if (sourceDirectory.isEmpty()) {
+        sourceDirectory = configuration.getSourceDirectory();
+    }
+    if (!sourceDirectory.isEmpty()) {
+        efmHandlerDialog->setSourceDirectory(sourceDirectory);
+    }
+
+    QString suggestedOutputBase;
+    const QString sourceFilename = tbcSource.getCurrentSourceFilename();
+    if (!sourceFilename.isEmpty()) {
+        const QFileInfo sourceInfo(sourceFilename);
+        suggestedOutputBase = QDir(sourceInfo.absolutePath())
+                                  .filePath(sourceInfo.completeBaseName());
+    } else if (!lastFilename.isEmpty()) {
+        const QFileInfo sourceInfo(lastFilename);
+        suggestedOutputBase = QDir(sourceInfo.absolutePath())
+                                  .filePath(sourceInfo.completeBaseName());
+    }
+    if (!suggestedOutputBase.isEmpty()) {
+        efmHandlerDialog->setSuggestedOutputBase(suggestedOutputBase);
+    }
+
+    efmHandlerDialog->show();
+    if (efmHandlerDialog->windowHandle() && windowHandle()) {
+        efmHandlerDialog->windowHandle()->setTransientParent(windowHandle());
+    }
+    efmHandlerDialog->raise();
+    efmHandlerDialog->activateWindow();
+    statusBar()->showMessage(tr("Opened EFM Handler. Configure EFM/AC3 stages and run the pipeline."), 5000);
+}
 // Start saving the modified metadata
 void MainWindow::on_actionSave_Metadata_triggered()
 {

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -440,12 +440,12 @@ QString resolveMetadataFilenameForSource(const QString &sourceFilename,
     };
 
     const auto appendCandidatesForFile = [&appendMetadataCandidate](const QFileInfo &info) {
-        appendMetadataCandidate(info.filePath() + QStringLiteral(".db"));
         appendMetadataCandidate(info.filePath() + QStringLiteral(".json"));
+        appendMetadataCandidate(info.filePath() + QStringLiteral(".db"));
 
         const QString basePath = QDir(info.absolutePath()).filePath(info.completeBaseName());
-        appendMetadataCandidate(basePath + QStringLiteral(".db"));
         appendMetadataCandidate(basePath + QStringLiteral(".json"));
+        appendMetadataCandidate(basePath + QStringLiteral(".db"));
 
         const QString suffix = info.suffix().toLower();
         if (suffix == QStringLiteral("ytbc")
@@ -453,9 +453,9 @@ QString resolveMetadataFilenameForSource(const QString &sourceFilename,
             || suffix == QStringLiteral("tbcy")
             || suffix == QStringLiteral("tbcc")) {
             appendMetadataCandidate(QDir(info.absolutePath())
-                                        .filePath(info.completeBaseName() + QStringLiteral(".tbc.db")));
-            appendMetadataCandidate(QDir(info.absolutePath())
                                         .filePath(info.completeBaseName() + QStringLiteral(".tbc.json")));
+            appendMetadataCandidate(QDir(info.absolutePath())
+                                        .filePath(info.completeBaseName() + QStringLiteral(".tbc.db")));
         }
     };
 
@@ -3036,10 +3036,10 @@ void MainWindow::loadTbcFile(QString inputFileName, bool forceMetadataOnly, bool
         }
 
         QString metadataCandidate;
-        if (QFileInfo::exists(dbCandidate)) {
-            metadataCandidate = dbCandidate;
-        } else if (QFileInfo::exists(jsonCandidate)) {
+        if (QFileInfo::exists(jsonCandidate)) {
             metadataCandidate = jsonCandidate;
+        } else if (QFileInfo::exists(dbCandidate)) {
+            metadataCandidate = dbCandidate;
         }
 
         if (metadataCandidate.isEmpty()) {

--- a/src/ld-analyse/mainwindow.h
+++ b/src/ld-analyse/mainwindow.h
@@ -293,6 +293,7 @@ private:
     bool isViewerTabActive() const;
     QString outputRootDirectoryForCurrentSource();
     QString outputBaseNameForCurrentSource();
+    void applyEfmHandlerAutoloads(const QString &directoryPath);
     void updateImageViewer();
     bool shouldRenderFrameAsync() const;
     void startAsyncFrameRender();

--- a/src/ld-analyse/mainwindow.h
+++ b/src/ld-analyse/mainwindow.h
@@ -56,6 +56,7 @@ namespace Ui {
 class MainWindow;
 }
 class AudioAlignmentDialog;
+class EfmHandlerDialog;
 class MetadataExportDialog;
 class NotesViewerDialog;
 class TimelineMarkerSlider;
@@ -104,6 +105,7 @@ private slots:
     void on_actionProcess_VITS_triggered();
     void on_actionFix_JSON_SNR_triggered();
     void on_actionAuto_Audio_Align_triggered();
+    void on_actionEFM_Handler_triggered();
 
     // Media control frame handlers
     void on_previousPushButton_clicked();
@@ -214,6 +216,7 @@ private:
     MetadataStatusDialog *metadataStatusDialog;
     ExportDialog *exportDialog;
     AudioAlignmentDialog *audioAlignmentDialog = nullptr;
+    EfmHandlerDialog *efmHandlerDialog = nullptr;
     MetadataExportDialog *metadataExportDialog = nullptr;
     NotesViewerDialog *notesViewerDialog = nullptr;
 

--- a/src/ld-analyse/mainwindow.ui
+++ b/src/ld-analyse/mainwindow.ui
@@ -797,6 +797,7 @@
     <addaction name="actionProcess_VITS"/>
     <addaction name="actionFix_JSON_SNR"/>
     <addaction name="actionAuto_Audio_Align"/>
+    <addaction name="actionEFM_Handler"/>
     <addaction name="separator"/>
     <addaction name="actionMetadata_Status"/>
     <addaction name="actionMetadata_Conversion"/>
@@ -876,6 +877,11 @@
   <action name="actionAuto_Audio_Align">
    <property name="text">
     <string>Auto Audio Align...</string>
+   </property>
+  </action>
+  <action name="actionEFM_Handler">
+   <property name="text">
+    <string>EFM Handler...</string>
    </property>
   </action>
   <action name="actionExit">

--- a/src/ld-analyse/tbcsource.cpp
+++ b/src/ld-analyse/tbcsource.cpp
@@ -1892,37 +1892,36 @@ bool TbcSource::startBackgroundLoad(QString sourceFilename)
     }
     auto metadataCandidatesForFile = [](const QFileInfo &info) {
         QStringList candidates;
-        candidates << (info.filePath() + QStringLiteral(".db"));
         candidates << (info.filePath() + QStringLiteral(".json"));
+        candidates << (info.filePath() + QStringLiteral(".db"));
         const QString basePath = QDir(info.absolutePath()).filePath(info.completeBaseName());
-        const QString baseDbCandidate = basePath + QStringLiteral(".db");
-        if (!candidates.contains(baseDbCandidate)) {
-            candidates << baseDbCandidate;
-        }
         const QString baseJsonCandidate = basePath + QStringLiteral(".json");
         if (!candidates.contains(baseJsonCandidate)) {
             candidates << baseJsonCandidate;
+        }
+        const QString baseDbCandidate = basePath + QStringLiteral(".db");
+        if (!candidates.contains(baseDbCandidate)) {
+            candidates << baseDbCandidate;
         }
         const QString suffix = info.suffix().toLower();
         if (suffix == QLatin1String("ytbc")
             || suffix == QLatin1String("ctbc")
             || suffix == QLatin1String("tbcy")
             || suffix == QLatin1String("tbcc")) {
-            const QString altDbCandidate = QDir(info.absolutePath())
-                                               .filePath(info.completeBaseName() + QStringLiteral(".tbc.db"));
-            if (!candidates.contains(altDbCandidate)) {
-                candidates << altDbCandidate;
-            }
             const QString altJsonCandidate = QDir(info.absolutePath())
                                                  .filePath(info.completeBaseName() + QStringLiteral(".tbc.json"));
             if (!candidates.contains(altJsonCandidate)) {
                 candidates << altJsonCandidate;
             }
+            const QString altDbCandidate = QDir(info.absolutePath())
+                                               .filePath(info.completeBaseName() + QStringLiteral(".tbc.db"));
+            if (!candidates.contains(altDbCandidate)) {
+                candidates << altDbCandidate;
+            }
         }
         return candidates;
     };
 
-    QString metadataFileName;
     QStringList metadataCandidates = metadataCandidatesForFile(QFileInfo(sourceFilename));
     if (isChromaTbc && lumaFilename != sourceFilename) {
         const QStringList lumaCandidates = metadataCandidatesForFile(QFileInfo(lumaFilename));
@@ -1932,27 +1931,26 @@ bool TbcSource::startBackgroundLoad(QString sourceFilename)
             }
         }
     }
+
+    QStringList metadataReadCandidates;
+    const auto appendMetadataReadCandidate = [&metadataReadCandidates](const QString &candidate) {
+        if (candidate.isEmpty()) {
+            return;
+        }
+        if (!metadataReadCandidates.contains(candidate, Qt::CaseInsensitive)) {
+            metadataReadCandidates << candidate;
+        }
+    };
     if (!requestedMetadataFilename.isEmpty()) {
         QFileInfo requestedInfo(requestedMetadataFilename);
         QString requestedPath = requestedMetadataFilename;
         if (requestedInfo.isRelative()) {
             requestedPath = QDir(sourceDir).filePath(requestedMetadataFilename);
         }
-        if (QFileInfo::exists(requestedPath)) {
-            metadataFileName = requestedPath;
-        }
+        appendMetadataReadCandidate(requestedPath);
     }
-
-    if (metadataFileName.isEmpty()) {
-        for (const QString &candidate : metadataCandidates) {
-            if (QFileInfo::exists(candidate)) {
-                metadataFileName = candidate;
-                break;
-            }
-        }
-        if (metadataFileName.isEmpty()) {
-            metadataFileName = metadataCandidates.first();
-        }
+    for (const QString &candidate : metadataCandidates) {
+        appendMetadataReadCandidate(candidate);
     }
 
     if (isChromaTbc && QFileInfo::exists(lumaFilename)) {
@@ -1960,9 +1958,25 @@ bool TbcSource::startBackgroundLoad(QString sourceFilename)
         sourceFilename = lumaFilename;
     }
 
-    if (!ldDecodeMetaData.read(metadataFileName)) {
-        // Open failed
-        qWarning() << "Open TBC metadata failed for filename" << metadataFileName;
+    QString metadataFileName;
+    QStringList failedMetadataCandidates;
+    for (const QString &candidate : metadataReadCandidates) {
+        if (!QFileInfo::exists(candidate)) {
+            continue;
+        }
+        if (ldDecodeMetaData.read(candidate)) {
+            metadataFileName = candidate;
+            break;
+        }
+        failedMetadataCandidates << candidate;
+    }
+
+    if (metadataFileName.isEmpty()) {
+        if (!failedMetadataCandidates.isEmpty()) {
+            qWarning() << "Open TBC metadata failed for candidates" << failedMetadataCandidates;
+        } else {
+            qWarning() << "Could not locate any metadata file from candidates" << metadataReadCandidates;
+        }
         currentSourceFilename.clear();
 
         // Show an error to the user and give up


### PR DESCRIPTION
## Summary
- add an EFM-Handler workflow dialog to ld-analyse and wire it into the UI/actions
- add directory autoload handling for EFM/AC3/PCM flows in ld-analyse
- make F2 metadata correction gaps non-fatal during processing
- harden EFM audio/data extraction paths with safer writer open handling, incomplete Data24 checks, and sector/padding sync/accounting fixes

## Validation
- nix develop -c cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
- nix develop -c ninja -C build
- nix develop -c ctest --test-dir build --output-on-failure -R "decode-pretbc-(ntsc-cav|ntsc-clv|pal-cav)" (3/3 passed)