### PR TITLE
Fix D1 gating for active-area framing adjustments

### DIFF
--- a/src/ld-analyse/exportarguments.cpp
+++ b/src/ld-analyse/exportarguments.cpp
@@ -8,5 +8,10 @@ bool shouldDisableDropoutCorrection(const QString &dropoutMode, int startFrameOn
     const QString normalizedMode = dropoutMode.trimmed().toLower();
     return normalizedMode == QStringLiteral("disabled");
 }
+bool isDefaultActiveAreaFraming(const QString &resolutionMode, bool hasAnyVerticalLineAdjustment)
+{
+    const QString normalizedMode = resolutionMode.trimmed().toLower();
+    return normalizedMode == QStringLiteral("active_area") && !hasAnyVerticalLineAdjustment;
+}
 
 }

--- a/src/ld-analyse/exportarguments.h
+++ b/src/ld-analyse/exportarguments.h
@@ -5,6 +5,7 @@
 
 namespace ExportArguments {
 bool shouldDisableDropoutCorrection(const QString &dropoutMode, int startFrameOneBased);
+bool isDefaultActiveAreaFraming(const QString &resolutionMode, bool hasAnyVerticalLineAdjustment);
 }
 
 #endif // EXPORTARGUMENTS_H

--- a/src/ld-analyse/exportdialog.cpp
+++ b/src/ld-analyse/exportdialog.cpp
@@ -3055,11 +3055,8 @@ void ExportDialog::on_exportButton_clicked()
         const bool supportsD1OutputSizing = executableSupportsD1OutputSizing(exportPath);
         const LdDecodeMetaData::VideoParameters &previewVideoParameters = tbcSource->getVideoParameters();
         const bool hasAnyVerticalLineAdjustment = hasAnyNonDefaultVerticalFraming(previewVideoParameters);
-        const bool hasSignificantVerticalLineAdjustment =
-            hasVerticalFramingDeltaBeyondThreshold(previewVideoParameters,
-                                                   kVerticalFramingAutoUserDefinedThreshold);
-    const bool hasCustomActiveLineFraming = resolutionMode == QStringLiteral("user_defined")
-                                            || hasSignificantVerticalLineAdjustment;
+        const bool isDefaultActiveAreaFraming =
+            ExportArguments::isDefaultActiveAreaFraming(resolutionMode, hasAnyVerticalLineAdjustment);
         const bool deinterlacedOutputProfile = isWebProfileName(selectedProfile);
         if (dropoutMode == QStringLiteral("heavy")
             && !executableSupportsOption(exportPath, QStringLiteral("--overcorrect"))) {
@@ -3085,7 +3082,7 @@ void ExportDialog::on_exportButton_clicked()
                                        && shouldUseD1OutputSizing(resolutionMode, outputResolutionMode)
                                        && supportsD1OutputSizing
                                        && !deinterlacedOutputProfile
-                                       && !hasCustomActiveLineFraming;
+                                       && isDefaultActiveAreaFraming;
         if (outputResamplePlan.enabled) {
             if (useD1OutputSizing) {
                 appendLog(tr("Output resolution mode '%1' will export %2x%3 with SAR %4 using --d1.")
@@ -3095,7 +3092,7 @@ void ExportDialog::on_exportButton_clicked()
                               .arg(outputResamplePlan.width)
                               .arg(outputResamplePlan.height)
                               .arg(outputResamplePlan.sampleAspectRatio));
-            } else if (hasCustomActiveLineFraming
+            } else if (!isDefaultActiveAreaFraming
                        && shouldUseD1OutputSizing(resolutionMode, outputResolutionMode)) {
                 appendLog(tr("D1 output sizing is unavailable when active-area framing has custom line adjustments; using filter-based or native sizing instead."));
             } else if (supportsAppendVideoFilter) {
@@ -5100,11 +5097,8 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
         }
     };
     const bool hasAnyVerticalLineAdjustment = hasAnyNonDefaultVerticalFraming(videoParameters);
-    const bool hasSignificantVerticalLineAdjustment =
-        hasVerticalFramingDeltaBeyondThreshold(videoParameters,
-                                               kVerticalFramingAutoUserDefinedThreshold);
-    const bool hasCustomActiveLineFraming = resolutionMode == QStringLiteral("user_defined")
-                                            || hasSignificantVerticalLineAdjustment;
+    const bool isDefaultActiveAreaFraming =
+        ExportArguments::isDefaultActiveAreaFraming(resolutionMode, hasAnyVerticalLineAdjustment);
     const bool letterboxCropRequested = ui->letterboxCropCheckBox
                                         && ui->letterboxCropCheckBox->isChecked();
     const bool forceAnamorphicRequested = ui->forceAnamorphicCheckBox
@@ -5127,7 +5121,7 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
         return QStringList();
     }
     if (letterboxCropRequested) {
-        if (resolutionMode != QStringLiteral("active_area") || hasCustomActiveLineFraming) {
+        if (!isDefaultActiveAreaFraming) {
             if (errorMessage) {
                 *errorMessage = tr("Letterbox crop is only available with default Active Area framing.");
             }
@@ -5195,7 +5189,7 @@ QStringList ExportDialog::buildArguments(QString *errorMessage, const QString &i
                                        && shouldUseD1OutputSizing(resolutionMode, outputResolutionMode)
                                        && executableSupportsD1OutputSizing(exportPath)
                                        && !deinterlacedOutputProfile
-                                       && !hasCustomActiveLineFraming;
+                                       && isDefaultActiveAreaFraming;
         if (useD1OutputSizing) {
             args << QStringLiteral("--d1");
         } else if (outputResamplePlan.enabled

--- a/src/ld-analyse/testexportarguments/testexportarguments.cpp
+++ b/src/ld-analyse/testexportarguments/testexportarguments.cpp
@@ -43,9 +43,19 @@ void testDropoutDisablePolicy()
     assert(ExportArguments::shouldDisableDropoutCorrection(QStringLiteral("disabled"), 1));
     assert(ExportArguments::shouldDisableDropoutCorrection(QStringLiteral("disabled"), 250));
 }
+void testDefaultActiveAreaFramingPolicy()
+{
+    cerr << "Testing ExportArguments::isDefaultActiveAreaFraming\n";
+
+    assert(ExportArguments::isDefaultActiveAreaFraming(QStringLiteral("active_area"), false));
+    assert(!ExportArguments::isDefaultActiveAreaFraming(QStringLiteral("active_area"), true));
+    assert(!ExportArguments::isDefaultActiveAreaFraming(QStringLiteral("active_vbi"), false));
+    assert(!ExportArguments::isDefaultActiveAreaFraming(QStringLiteral("user_defined"), false));
+}
 
 int main()
 {
     testDropoutDisablePolicy();
+    testDefaultActiveAreaFramingPolicy();
     return 0;
 }


### PR DESCRIPTION
## Summary
- require strict default active-area framing before emitting `--d1/--standard`
- align preview/build-path gating and letterbox gating with the same default-framing check
- add regression coverage for `isDefaultActiveAreaFraming(...)` in `testexportarguments`

## Validation
- `ninja -C /home/harry/tbc-tools/build-nocuda-check ld-analyse testexportarguments`
- `ctest --test-dir /home/harry/tbc-tools/build-nocuda-check --output-on-failure -R testexportarguments`
- `tbc-video-export --input-tbc-json "/media/harry/20TB HDD1/Lukas_etothepiisreal_Europe_2025/Tape_16/Tape_16_Decoded.tbc.json" --start 1 --length 100 "/media/harry/20TB HDD1/Lukas_etothepiisreal_Europe_2025/Tape_16/Tape_16_Decoded.tbc" "/media/harry/20TB HDD1/Lukas_etothepiisreal_Europe_2025/Tape_16/Tape_16_Decoded_test_100f"` (succeeded)

## Context
- Conversation: https://app.warp.dev/conversation/9bf1520d-b177-4ac9-be7f-84f3652ae0a6

Co-Authored-By: Oz <oz-agent@warp.dev>