### PR TITLE
Fix macOS dylib bundling and add CoreML provider support

### DIFF
--- a/.github/workflows/build_macos_tools.yml
+++ b/.github/workflows/build_macos_tools.yml
@@ -31,8 +31,6 @@ jobs:
 
     name: Build tbc-tools (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    env:
-      LDDECODE_NNTRANSFORM3D_PROVIDER: cpu
 
     steps:
       - uses: actions/checkout@v5
@@ -284,11 +282,6 @@ jobs:
             file "$1" 2>/dev/null | grep -q "Mach-O"
           }
 
-          exports_symbol() {
-            local file="$1"
-            local symbol="$2"
-            nm -gU "$file" 2>/dev/null | grep -Eq "(^|[[:space:]])${symbol}$"
-          }
           dep_unique_name() {
             local dep="$1"
             if [[ "$dep" == /nix/store/* ]]; then
@@ -383,22 +376,24 @@ jobs:
             local deps
             deps=$(otool -L "$file" 2>/dev/null | tail -n +2 | awk "{print \$1}" || true)
             for dep in $deps; do
+              local store_dep=""
               case "$dep" in
                 # Keep runtime dependency capture strictly in Nix store paths.
                 # Mixing host Homebrew dylibs with Nix dylibs can cause ABI
                 # mismatches (for example libidn2 expecting GNU libiconv symbols
                 # while a different host libiconv is bundled first).
                 /nix/store/*)
-                  local target
-                  target=$(copy_dep "$dep")
-                  local newref
-                  newref=$(newref_for_dep "$dep")
-                  install_name_tool -change "$dep" "$newref" "$file" 2>/dev/null || true
-                  [ -n "$target" ] && QUEUE+=("$target")
-                  ;;
-                *)
+                  store_dep="$dep"
                   ;;
               esac
+              if [ -n "$store_dep" ]; then
+                local target
+                target=$(copy_dep "$store_dep")
+                local newref
+                newref=$(newref_for_dep "$store_dep")
+                install_name_tool -change "$dep" "$newref" "$file" 2>/dev/null || true
+                [ -n "$target" ] && QUEUE+=("$target")
+              fi
             done
           }
 
@@ -460,21 +455,6 @@ jobs:
             exit 1
           fi
           FW_DIR="dist/tbc-tools.app/Contents/Frameworks"
-          SYMBOL_EXPORT_CACHE_DIR=$(mktemp -d)
-          symbol_export_cache_file() {
-            local lib="$1"
-            local key
-            key=$(printf '%s' "$lib" | shasum | awk '{print $1}')
-            echo "$SYMBOL_EXPORT_CACHE_DIR/$key.exports"
-          }
-          cache_exported_symbols() {
-            local lib="$1"
-            local cache_file
-            cache_file=$(symbol_export_cache_file "$lib")
-            if [ ! -f "$cache_file" ]; then
-              nm -gUj "$lib" 2>/dev/null | sed '/^$/d' | sort -u > "$cache_file" || true
-            fi
-          }
           resolve_bundled_dep_path() {
             local dep="$1"
             case "$dep" in
@@ -499,59 +479,45 @@ jobs:
             fi
             return 1
           }
-          verify_bundled_symbol_links() {
+          verify_bundled_dependencies() {
             local failures=0
             while IFS= read -r -d '' macho_file; do
               if ! file "$macho_file" 2>/dev/null | grep -q "Mach-O"; then
                 continue
               fi
-              while IFS=$'\t' read -r symbol dep; do
-                [ -n "$symbol" ] || continue
+              while IFS= read -r dep; do
                 [ -n "$dep" ] || continue
-                local dep_path
-                dep_path=$(resolve_bundled_dep_path "$dep" || true)
-                if [ -z "$dep_path" ]; then
-                  continue
-                fi
-                cache_exported_symbols "$dep_path"
-                local cache_file
-                cache_file=$(symbol_export_cache_file "$dep_path")
-                if ! grep -Fxq "$symbol" "$cache_file"; then
-                  echo "Missing bundled symbol reference:"
-                  echo "  Symbol: $symbol"
+                case "$dep" in
+                  /System/*|/usr/lib/*|/Library/Frameworks/*)
+                    continue
+                    ;;
+                  @*|/*)
+                    ;;
+                  *)
+                    # otool prints "dynamically looked up" / "flat namespace"
+                    # entries that awk '{print $1}' truncates to single tokens.
+                    # Anything not starting with / or @ is one of those.
+                    continue
+                    ;;
+                esac
+                if ! resolve_bundled_dep_path "$dep" >/dev/null 2>&1; then
+                  echo "Unresolved bundled dependency:"
                   echo "  Required by: $macho_file"
                   echo "  Declared dependency: $dep"
-                  echo "  Resolved bundled dylib: $dep_path"
                   failures=1
                 fi
-              done < <(
-                nm -m "$macho_file" 2>/dev/null | awk '
-                  /\(undefined\)/ && /\(from / && $0 !~ / weak / {
-                    sym=""; dep="";
-                    if (match($0, / (external|private external) ([^ ]+)/, m)) {
-                      sym=m[2];
-                    }
-                    if (match($0, /\(from ([^)]+)\)/, d)) {
-                      dep=d[1];
-                    }
-                    if (sym != "" && dep != "") {
-                      print sym "\t" dep;
-                    }
-                  }'
-              )
+              done < <(otool -L "$macho_file" 2>/dev/null | tail -n +2 | awk '{print $1}')
             done < <(find dist/tbc-tools.app/Contents -type f -print0)
             if [ "$failures" -ne 0 ]; then
-              echo "Bundled symbol verification failed."
+              echo "Bundled dependency verification failed."
               return 1
             fi
-            echo "Bundled symbol verification passed."
+            echo "Bundled dependency verification passed."
             return 0
           }
-          if ! verify_bundled_symbol_links; then
-            rm -rf "$SYMBOL_EXPORT_CACHE_DIR"
+          if ! verify_bundled_dependencies; then
             exit 1
           fi
-          rm -rf "$SYMBOL_EXPORT_CACHE_DIR"
           for tool in ffmpeg ffprobe; do
             tool_path="dist/tbc-tools.app/Contents/MacOS/$tool"
             if [ ! -x "$tool_path" ]; then

--- a/ci/check_ci_contracts.py
+++ b/ci/check_ci_contracts.py
@@ -51,7 +51,6 @@ MACOS_REQUIRED_SNIPPETS = (
     "workflow_dispatch:",
     "workflow_call:",
     "macos-15-intel",
-    "LDDECODE_NNTRANSFORM3D_PROVIDER: cpu",
     "for item in result/bin/*; do",
     "result/share/tbc-video-export",
     "Missing vendored exporter tool: dist/tbc-tools.app/Contents/MacOS/tbc-video-export",
@@ -59,9 +58,9 @@ MACOS_REQUIRED_SNIPPETS = (
     "tbc-tools.app/Contents/MacOS/tbc-video-export --version",
     "/nix/store/*)",
     "dep_unique_name()",
-    "verify_bundled_symbol_links()",
-    "Missing bundled symbol reference:",
-    "Bundled symbol verification failed.",
+    "verify_bundled_dependencies()",
+    "Unresolved bundled dependency:",
+    "Bundled dependency verification failed.",
 )
 
 RELEASE_REQUIRED_SNIPPETS = (

--- a/ci/tests/test_check_ci_contracts.py
+++ b/ci/tests/test_check_ci_contracts.py
@@ -85,14 +85,13 @@ class ContractCoverageTests(unittest.TestCase):
         expected = {
             "workflow_dispatch:",
             "workflow_call:",
-            "LDDECODE_NNTRANSFORM3D_PROVIDER: cpu",
             "result/share/tbc-video-export",
             "tbc-tools.app/Contents/MacOS/tbc-video-export --version",
             "/nix/store/*)",
             "dep_unique_name()",
-            "verify_bundled_symbol_links()",
-            "Missing bundled symbol reference:",
-            "Bundled symbol verification failed.",
+            "verify_bundled_dependencies()",
+            "Unresolved bundled dependency:",
+            "Bundled dependency verification failed.",
         }
         self.assertTrue(expected.issubset(set(check_ci_contracts.MACOS_REQUIRED_SNIPPETS)))
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,53 @@
                 runHook postInstall
               '';
             }
+          else if isDarwin then
+            # Microsoft prebuilt for CoreML EP (nixpkgs lacks it). 1.23.2
+            # is the last release with matching arm64+x86_64 thin builds,
+            # required for the universal DMG's per-arch lipo merge.
+            let
+              archSuffix =
+                if pkgsUnstable.stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64";
+              archSha256 =
+                if pkgsUnstable.stdenv.hostPlatform.isAarch64
+                then "sha256-tNUTqysm8IjGaJHbvBQIFmcIdz18xBY9573KDpu7eFY="
+                else "sha256-0QNZ4WNHtX2ZWffoCiJaW0pm7X1+AHJ0oVyuhoNkhaY=";
+            in
+            pkgsUnstable.stdenvNoCC.mkDerivation rec {
+              pname = "onnxruntime-osx-${archSuffix}-prebuilt";
+              version = "1.23.2";
+              src = pkgsUnstable.fetchurl {
+                url = "https://github.com/microsoft/onnxruntime/releases/download/v${version}/onnxruntime-osx-${archSuffix}-${version}.tgz";
+                sha256 = archSha256;
+              };
+              sourceRoot = "onnxruntime-osx-${archSuffix}-${version}";
+              # stdenvNoCC omits cctools, so install_name_tool isn't on PATH.
+              # autoSignDarwinBinariesHook re-signs ad-hoc in fixupPhase after
+              # install_name_tool invalidates Microsoft's signature.
+              nativeBuildInputs = [
+                pkgsUnstable.cctools
+                pkgsUnstable.darwin.autoSignDarwinBinariesHook
+              ];
+              dontConfigure = true;
+              dontBuild = true;
+              # Strip Microsoft's broken onnxruntimeTargets.cmake (declares
+              # include/onnxruntime/ which the tgz doesn't ship) so
+              # find_package falls back to ONNXRUNTIME_ROOT include. Also
+              # rewrite the dylib's install_name from @rpath/... to its
+              # absolute store path (nix convention for a prebuilt) so we
+              # don't need nix-specific LC_RPATH workarounds in the built
+              # installables.
+              installPhase = ''
+                runHook preInstall
+                mkdir -p "$out"
+                cp -r ./* "$out"/
+                rm -rf "$out/lib/cmake"
+                install_name_tool -id \
+                  "$out/lib/libonnxruntime.${version}.dylib" \
+                  "$out/lib/libonnxruntime.${version}.dylib"
+                runHook postInstall
+              '';
+            }
           else
             pkgs.onnxruntime;
         cudaRuntimeDependencies = pkgs.lib.optionals isLinux [
@@ -125,6 +172,7 @@
             "-DAPP_COMMIT=${nixCommit}"
           ] ++ pkgs.lib.optionals isDarwin [
             "-DLDCHROMA_ENABLE_CUDA=OFF"
+            "-DONNXRUNTIME_ROOT=${onnxruntimePackage}"
           ] ++ pkgs.lib.optionals isLinux [
             "-DCUDAToolkit_ROOT=${cudaPackages.cudatoolkit}"
             "-DCMAKE_CUDA_HOST_COMPILER=${cudaHostCompiler}/bin/g++"

--- a/src/ld-chroma-decoder/CMakeLists.txt
+++ b/src/ld-chroma-decoder/CMakeLists.txt
@@ -87,7 +87,12 @@ endif()
 # 2. Locate external deep-learning and GPU dependencies
 # ==========================================
 
-find_path(ONNXRUNTIME_INCLUDE_DIR NAMES onnxruntime_cxx_api.h PATHS ${ONNXRUNTIME_ROOT}/include $ENV{ONNXRUNTIME_ROOT}/include)
+find_path(ONNXRUNTIME_INCLUDE_DIR NAMES onnxruntime_cxx_api.h PATHS
+    ${ONNXRUNTIME_ROOT}/include
+    ${ONNXRUNTIME_ROOT}/include/onnxruntime
+    $ENV{ONNXRUNTIME_ROOT}/include
+    $ENV{ONNXRUNTIME_ROOT}/include/onnxruntime
+)
 find_library(ONNXRUNTIME_LIBRARY NAMES onnxruntime PATHS ${ONNXRUNTIME_ROOT}/lib $ENV{ONNXRUNTIME_ROOT}/lib)
 
 if(NOT ONNXRUNTIME_INCLUDE_DIR OR NOT ONNXRUNTIME_LIBRARY)

--- a/src/ld-chroma-decoder/comb.cpp
+++ b/src/ld-chroma-decoder/comb.cpp
@@ -38,6 +38,8 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #ifdef __linux__
@@ -123,7 +125,8 @@ constexpr const char *kOnnxRuntimeRootEnvVar = "ONNXRUNTIME_ROOT";
 enum class NnExecutionProviderPreference {
     Auto,
     Cpu,
-    Cuda
+    Cuda,
+    CoreML
 };
 
 NnExecutionProviderPreference getNnExecutionProviderPreference()
@@ -137,6 +140,9 @@ NnExecutionProviderPreference getNnExecutionProviderPreference()
     }
     if (provider == "cuda" || provider == "gpu") {
         return NnExecutionProviderPreference::Cuda;
+    }
+    if (provider == "coreml") {
+        return NnExecutionProviderPreference::CoreML;
     }
 
     qWarning() << "Unknown" << kNnProviderEnvVar << "value:" << provider << "- using auto";
@@ -152,6 +158,8 @@ QString providerPreferenceToString(NnExecutionProviderPreference preference)
         return QStringLiteral("cpu");
     case NnExecutionProviderPreference::Cuda:
         return QStringLiteral("cuda");
+    case NnExecutionProviderPreference::CoreML:
+        return QStringLiteral("coreml");
     }
     return QStringLiteral("auto");
 }
@@ -496,6 +504,27 @@ bool appendCudaExecutionProvider(Ort::SessionOptions &options, QString &errorMes
 
     releaseCudaOptions();
     return true;
+}
+
+bool appendCoreMLExecutionProvider(Ort::SessionOptions &options, QString &errorMessage)
+{
+#if defined(__APPLE__)
+    try {
+        const std::unordered_map<std::string, std::string> coremlOptions = {
+            { "MLComputeUnits", "ALL" },
+            { "ModelFormat", "MLProgram" },
+        };
+        options.AppendExecutionProvider("CoreML", coremlOptions);
+        return true;
+    } catch (const std::exception &e) {
+        errorMessage = QString::fromUtf8(e.what());
+        return false;
+    }
+#else
+    Q_UNUSED(options)
+    errorMessage = QStringLiteral("CoreML execution provider is only available on macOS");
+    return false;
+#endif
 }
 }
 
@@ -862,12 +891,23 @@ bool Comb::FrameBuffer::split3DnnTransform(FrameBuffer &nextFrame, qint32 frameI
 
             #if defined(__APPLE__)
             const bool allowCuda = false;
+            // ORT's CoreML EP currently rejects 3D Conv (deliberate gate in
+            // conv_op_builder.cc), so for this model every Conv falls back to
+            // CPU and CoreML is a net ~7% regression. Keep it opt-in via an
+            // explicit LDDECODE_NNTRANSFORM3D_PROVIDER=coreml until that lands.
+            const bool allowCoreML = providerPreference == NnExecutionProviderPreference::CoreML;
             if (providerPreference == NnExecutionProviderPreference::Cuda) {
                 qWarning() << "Ignoring" << kNnProviderEnvVar
                            << "=cuda on macOS; using CPU provider";
             }
             #else
-            const bool allowCuda = providerPreference != NnExecutionProviderPreference::Cpu;
+            const bool allowCuda = providerPreference != NnExecutionProviderPreference::Cpu
+                                && providerPreference != NnExecutionProviderPreference::CoreML;
+            const bool allowCoreML = false;
+            if (providerPreference == NnExecutionProviderPreference::CoreML) {
+                qWarning() << "Ignoring" << kNnProviderEnvVar
+                           << "=coreml on non-Apple platforms; using CPU provider";
+            }
             #endif
 
             if (allowCuda) {
@@ -879,6 +919,18 @@ bool Comb::FrameBuffer::split3DnnTransform(FrameBuffer &nextFrame, qint32 frameI
                     tryCreateSession(cudaOptions, QStringLiteral("CUDA"));
                 } else {
                     qWarning() << "Unable to enable nnTransform3D CUDA provider:" << appendError;
+                }
+            }
+
+            if (!onnxReady && allowCoreML) {
+                Ort::SessionOptions coremlOptions;
+                configureSessionOptions(coremlOptions);
+
+                QString appendError;
+                if (appendCoreMLExecutionProvider(coremlOptions, appendError)) {
+                    tryCreateSession(coremlOptions, QStringLiteral("CoreML"));
+                } else {
+                    qWarning() << "Unable to enable nnTransform3D CoreML provider:" << appendError;
                 }
             }
 


### PR DESCRIPTION
Restores macOS releases (broken in v3.1.0/v3.1.1 with `dyld: Library not loaded: @rpath/libonnxruntime.X.Y.Z.dylib`) and adds opt-in CoreML execution provider support. Both fixes are independent of each other but share the package switch to Microsoft's onnxruntime prebuilt (nixpkgs's build lacks CoreML EP). Fixes harrypm/tbc-tools#15.

- **Bundling fix:** rewrites libonnxruntime's `@rpath/` install_name to its absolute Nix store path in `flake.nix`, so consumers record an absolute dep entry and the bundler's existing `/nix/store/*` code path handles relocation. Adds `verify_bundled_dependencies` to fail CI if any non-system dep isn't in `Frameworks/` (the safety net v3.1.0 lacked).
- **CoreML EP plumbing:** new `LDDECODE_NNTRANSFORM3D_PROVIDER=coreml` opt-in. Defaults to CPU on macOS because ORT's CoreML EP rejects 3D Conv (so every Conv falls back to CPU while CoreML only handles activations—measured ~7% slower than CPU on the current model).

See the commit body for full details on the install_name mechanism and why `INSTALL_RPATH_USE_LINK_PATH TRUE` is silently defeated by Nix's CC wrapper on macOS.

Collabed with [Claude Code](https://claude.com/claude-code).