### PR TITLE
CI: run release-style builds in Tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Run CI guardrails
         run: bash ci/run_local_ci_parity.sh --guardrails-only
   full-build-test:
-    name: Full build and test
+    name: Full Linux build and test parity
+    needs: ci-guardrails
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
         with:
@@ -41,5 +43,25 @@ jobs:
             nix-${{ runner.os }}-
           gc-max-store-size-linux: 6G
       - name: Build and test full parity flow
-        timeout-minutes: 20
         run: bash ci/run_local_ci_parity.sh --build-test-only
+  build-linux-release-style:
+    name: Release-style Linux packaging build
+    needs: ci-guardrails
+    uses: ./.github/workflows/build_linux_tools.yml
+    with:
+      checkout_ref: ${{ github.sha }}
+    secrets: inherit
+  build-windows-release-style:
+    name: Release-style Windows packaging build
+    needs: ci-guardrails
+    uses: ./.github/workflows/build_windows_tools.yml
+    with:
+      checkout_ref: ${{ github.sha }}
+    secrets: inherit
+  build-macos-release-style:
+    name: Release-style macOS packaging build
+    needs: ci-guardrails
+    uses: ./.github/workflows/build_macos_tools.yml
+    with:
+      checkout_ref: ${{ github.sha }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- update `.github/workflows/tests.yml` so `Tests` now runs release-style packaging jobs for Linux, Windows, and macOS via reusable workflows
- keep a real Linux compile+test parity job and increase its timeout to 90 minutes to avoid premature timeout failures
- gate all heavy jobs behind successful CI guardrails

## Validation

- `python3 -m unittest -v ci.tests.test_check_ci_contracts`
- `python3 ci/check_ci_contracts.py
