### PR TITLE
Add YUV scope/histogram, broadcast range clipping overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance to WARP (warp.dev) when working with code in this repository.
+This file provides guidance to AI agents when working with code in this repository.
 
 ## Project Overview
 

--- a/src/ld-analyse/CMakeLists.txt
+++ b/src/ld-analyse/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ld-analyse_SOURCES
     ../tbc-export-metadata/metadataexportdialog.cpp ../tbc-export-metadata/metadataexportdialog.h ../tbc-export-metadata/metadataexportdialog.ui
     oscilloscopedialog.cpp oscilloscopedialog.ui
     rgbscopedialog.cpp rgbscopedialog.h
+    yuvrangedialog.cpp yuvrangedialog.h
     vectorscopedialog.cpp vectorscopedialog.ui
     fieldtimingdialog.cpp fieldtimingdialog.h
     fieldtimingwidget.cpp fieldtimingwidget.h

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -1347,6 +1347,7 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
     // Set up dialogues
     oscilloscopeDialog = new OscilloscopeDialog(this);
     rgbScopeDialog = new RgbScopeDialog(this);
+    yuvRangeDialog = new YuvRangeDialog(this);
     vectorscopeDialog = new VectorscopeDialog(this);
     fieldTimingDialog = new FieldTimingDialog(this);
     aboutDialog = new AboutDialog(this);
@@ -1494,6 +1495,12 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
         }
         updateRgbScopeDialogue(false);
     });
+    connect(yuvRangeDialog, &YuvRangeDialog::renderTargetSizeChanged, this, [this](const QSize &) {
+        if (!yuvRangeDialog || !yuvRangeDialog->isVisible() || yuvRangeDialog->isMinimized()) {
+            return;
+        }
+        updateYuvRangeScopeDialogue(false);
+    });
 
     // Connect to the video parameters changed signal
     connect(videoParametersDialog, &VideoParametersDialog::videoParametersChanged, this, &MainWindow::videoParametersChangedSignalHandler);
@@ -1561,6 +1568,14 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
         rgbScopeRefreshPending = false;
         if (rgbScopeDialog && rgbScopeDialog->isVisible()) {
             updateRgbScopeDialogue(true);
+        }
+    });
+    yuvRangeScopeRefreshTimer = new QTimer(this);
+    yuvRangeScopeRefreshTimer->setSingleShot(true);
+    connect(yuvRangeScopeRefreshTimer, &QTimer::timeout, this, [this]() {
+        yuvRangeScopeRefreshPending = false;
+        if (yuvRangeDialog && yuvRangeDialog->isVisible()) {
+            updateYuvRangeScopeDialogue(true);
         }
     });
     
@@ -1760,6 +1775,7 @@ void MainWindow::setGuiEnabled(bool enabled)
     // Enable menu options
     ui->actionLine_scope->setEnabled(enabled);
     ui->actionRGB_scope->setEnabled(enabled);
+    ui->actionYUV_range_scope->setEnabled(enabled);
     ui->actionVectorscope->setEnabled(enabled);
     ui->actionField_timing_scope->setEnabled(enabled);
     ui->actionVBI->setEnabled(enabled);
@@ -2124,6 +2140,7 @@ void MainWindow::updateGuiLoaded()
         ui->actionSave_frame_as_PNG->setEnabled(false);
         ui->actionLine_scope->setEnabled(false);
         ui->actionRGB_scope->setEnabled(false);
+        ui->actionYUV_range_scope->setEnabled(false);
         ui->actionVectorscope->setEnabled(false);
         ui->actionField_timing_scope->setEnabled(false);
     }
@@ -2232,11 +2249,17 @@ void MainWindow::updateGuiUnloaded()
     chromaDecoderConfigDialog->hide();
     fieldTimingDialog->hide();
     rgbScopeDialog->hide();
+    yuvRangeDialog->hide();
     if (rgbScopeRefreshTimer) {
         rgbScopeRefreshTimer->stop();
     }
     rgbScopeRefreshPending = false;
     rgbScopeLastRefreshMs = 0;
+    if (yuvRangeScopeRefreshTimer) {
+        yuvRangeScopeRefreshTimer->stop();
+    }
+    yuvRangeScopeRefreshPending = false;
+    yuvRangeScopeLastRefreshMs = 0;
     updateTimelineMarkers();
     updateNotesViewerState();
 
@@ -2577,6 +2600,9 @@ void MainWindow::updateImage()
     }
     if (rgbScopeDialog->isVisible() && !rgbScopeDialog->isMinimized()) {
         updateRgbScopeDialogue();
+    }
+    if (yuvRangeDialog->isVisible() && !yuvRangeDialog->isMinimized()) {
+        updateYuvRangeScopeDialogue();
     }
     if (vectorscopeDialog->isVisible()) {
         updateVectorscopeDialogue();
@@ -3339,6 +3365,36 @@ void MainWindow::updateRgbScopeDialogue(bool force)
     if (rgbScopeRefreshTimer && rgbScopeRefreshPending) {
         rgbScopeRefreshTimer->stop();
         rgbScopeRefreshPending = false;
+    }
+}
+
+void MainWindow::updateYuvRangeScopeDialogue(bool force)
+{
+    if (!yuvRangeDialog || !tbcSource.getIsSourceLoaded() || tbcSource.getIsMetadataOnly()) {
+        return;
+    }
+    if (asyncFrameRenderInProgress && shouldRenderFrameAsync()) {
+        return;
+    }
+
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 minRefreshIntervalMs = playbackRunning ? 180 : 80;
+    if (!force && yuvRangeScopeLastRefreshMs > 0) {
+        const qint64 elapsedMs = nowMs - yuvRangeScopeLastRefreshMs;
+        if (elapsedMs < minRefreshIntervalMs) {
+            if (yuvRangeScopeRefreshTimer && !yuvRangeScopeRefreshPending) {
+                yuvRangeScopeRefreshPending = true;
+                yuvRangeScopeRefreshTimer->start(static_cast<int>(minRefreshIntervalMs - elapsedMs));
+            }
+            return;
+        }
+    }
+
+    yuvRangeDialog->showScopeImage(tbcSource.getYuvRangeScopeImage(yuvRangeDialog->scopeRenderTargetSize()));
+    yuvRangeScopeLastRefreshMs = nowMs;
+    if (yuvRangeScopeRefreshTimer && yuvRangeScopeRefreshPending) {
+        yuvRangeScopeRefreshTimer->stop();
+        yuvRangeScopeRefreshPending = false;
     }
 }
 
@@ -5056,6 +5112,21 @@ void MainWindow::on_actionRGB_scope_triggered()
     rgbScopeDialog->raise();
     rgbScopeDialog->activateWindow();
 }
+
+// Display the YUV range scope pop-out view
+void MainWindow::on_actionYUV_range_scope_triggered()
+{
+    if (!tbcSource.getIsSourceLoaded() || tbcSource.getIsMetadataOnly()) {
+        return;
+    }
+    if (!yuvRangeDialog->isVisible()) {
+        yuvRangeDialog->show();
+    }
+    updateYuvRangeScopeDialogue(true);
+    yuvRangeDialog->raise();
+    yuvRangeDialog->activateWindow();
+}
+
 // Display the field timing scope view
 void MainWindow::on_actionField_timing_scope_triggered()
 {

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -1348,6 +1348,7 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
     oscilloscopeDialog = new OscilloscopeDialog(this);
     rgbScopeDialog = new RgbScopeDialog(this);
     yuvRangeDialog = new YuvRangeDialog(this);
+    yuvRangeSettings = yuvRangeDialog->settings();
     vectorscopeDialog = new VectorscopeDialog(this);
     fieldTimingDialog = new FieldTimingDialog(this);
     aboutDialog = new AboutDialog(this);
@@ -1500,6 +1501,13 @@ MainWindow::MainWindow(QString inputFilenameParam, bool metadataOnlyParam, QWidg
             return;
         }
         updateYuvRangeScopeDialogue(false);
+    });
+    connect(yuvRangeDialog, &YuvRangeDialog::settingsChanged, this, [this](const YuvRangeSettings &settings) {
+        yuvRangeSettings = settings;
+        if (yuvRangeDialog && yuvRangeDialog->isVisible() && !yuvRangeDialog->isMinimized()) {
+            updateYuvRangeScopeDialogue(true);
+        }
+        updateImageViewer();
     });
 
     // Connect to the video parameters changed signal
@@ -2803,6 +2811,17 @@ void MainWindow::updateImageViewer()
         QPixmap scaledPixmap = pixmap.scaled(width, height,
                                              Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
+        if (yuvRangeSettings.overlayEnabled && !tbcSource.getIsMetadataOnly()) {
+            const QImage overlayImage = tbcSource.getYuvRangeOverlayImage(yuvRangeSettings);
+            if (!overlayImage.isNull() && overlayImage.width() > 0 && overlayImage.height() > 0) {
+                const QPixmap scaledOverlay = QPixmap::fromImage(overlayImage).scaled(
+                    scaledPixmap.size(), Qt::IgnoreAspectRatio, Qt::FastTransformation);
+                QPainter painter(&scaledPixmap);
+                painter.setRenderHint(QPainter::Antialiasing, false);
+                painter.drawPixmap(0, 0, scaledOverlay);
+            }
+        }
+
         if (showExportBoundary) {
             const QVector<QRect> activeRects = getActiveVideoRects();
             if (!activeRects.isEmpty() && pixmap.width() > 0 && pixmap.height() > 0) {
@@ -3390,7 +3409,7 @@ void MainWindow::updateYuvRangeScopeDialogue(bool force)
         }
     }
 
-    yuvRangeDialog->showScopeImage(tbcSource.getYuvRangeScopeImage(yuvRangeDialog->scopeRenderTargetSize()));
+    yuvRangeDialog->showScopeImage(tbcSource.getYuvRangeScopeImage(yuvRangeDialog->scopeRenderTargetSize(), yuvRangeSettings));
     yuvRangeScopeLastRefreshMs = nowMs;
     if (yuvRangeScopeRefreshTimer && yuvRangeScopeRefreshPending) {
         yuvRangeScopeRefreshTimer->stop();

--- a/src/ld-analyse/mainwindow.h
+++ b/src/ld-analyse/mainwindow.h
@@ -272,6 +272,7 @@ private:
     QTimer* yuvRangeScopeRefreshTimer = nullptr;
     bool yuvRangeScopeRefreshPending = false;
     qint64 yuvRangeScopeLastRefreshMs = 0;
+    YuvRangeSettings yuvRangeSettings;
     
     // Chroma toggle during seek
     bool chromaSeekMode;

--- a/src/ld-analyse/mainwindow.h
+++ b/src/ld-analyse/mainwindow.h
@@ -36,6 +36,7 @@
 
 #include "oscilloscopedialog.h"
 #include "rgbscopedialog.h"
+#include "yuvrangedialog.h"
 #include "vectorscopedialog.h"
 #include "fieldtimingdialog.h"
 #include "aboutdialog.h"
@@ -83,6 +84,7 @@ private slots:
     void on_actionSave_Metadata_triggered();
     void on_actionLine_scope_triggered();
     void on_actionRGB_scope_triggered();
+    void on_actionYUV_range_scope_triggered();
     void on_actionVectorscope_triggered();
     void on_actionField_timing_scope_triggered();
     void on_actionTBC_Tools_Wiki_triggered();
@@ -210,6 +212,7 @@ private:
     // Dialogues
     OscilloscopeDialog* oscilloscopeDialog;
     RgbScopeDialog *rgbScopeDialog;
+    YuvRangeDialog *yuvRangeDialog;
     VectorscopeDialog* vectorscopeDialog;
     FieldTimingDialog* fieldTimingDialog;
     AboutDialog* aboutDialog;
@@ -266,6 +269,9 @@ private:
     QTimer* rgbScopeRefreshTimer = nullptr;
     bool rgbScopeRefreshPending = false;
     qint64 rgbScopeLastRefreshMs = 0;
+    QTimer* yuvRangeScopeRefreshTimer = nullptr;
+    bool yuvRangeScopeRefreshPending = false;
+    qint64 yuvRangeScopeLastRefreshMs = 0;
     
     // Chroma toggle during seek
     bool chromaSeekMode;
@@ -339,6 +345,7 @@ private:
     void cleanupTempMetadataFile();
     void updateOscilloscopeDialogue();
     void updateRgbScopeDialogue(bool force = false);
+    void updateYuvRangeScopeDialogue(bool force = false);
     void updateVectorscopeDialogue();
     void updateFieldTimingDialogue();
     void populateThemesMenu();

--- a/src/ld-analyse/mainwindow.ui
+++ b/src/ld-analyse/mainwindow.ui
@@ -767,6 +767,7 @@
     <addaction name="actionVectorscope"/>
     <addaction name="actionLine_scope"/>
     <addaction name="actionRGB_scope"/>
+    <addaction name="actionYUV_range_scope"/>
     <addaction name="actionField_timing_scope"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -905,6 +906,11 @@
   <action name="actionRGB_scope">
    <property name="text">
     <string>RGB scope...</string>
+   </property>
+  </action>
+  <action name="actionYUV_range_scope">
+   <property name="text">
+    <string>YUV range...</string>
    </property>
   </action>
   <action name="actionVectorscope">

--- a/src/ld-analyse/rgbscopedialog.cpp
+++ b/src/ld-analyse/rgbscopedialog.cpp
@@ -29,7 +29,8 @@ RgbScopeDialog::RgbScopeDialog(QWidget *parent)
 
     scopeLabel_ = new QLabel(this);
     scopeLabel_->setAlignment(Qt::AlignCenter);
-    scopeLabel_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    scopeLabel_->setMinimumSize(1, 1);
+    scopeLabel_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
     scopeLabel_->setScaledContents(false);
     scopeLabel_->setText(tr("No RGB scope data"));
     mainLayout->addWidget(scopeLabel_);

--- a/src/ld-analyse/tbcsource.cpp
+++ b/src/ld-analyse/tbcsource.cpp
@@ -19,10 +19,67 @@
 
 #include "tbcsource.h"
 #include "tbc/logging.h"
+#include "yuvrangedialog.h"
 
 #include "sourcefield.h"
 
 namespace {
+struct YuvRangeScale {
+    double yScale = 0.0;
+    double cbScale = 0.0;
+    double crScale = 0.0;
+    double blackLevel = 0.0;
+    bool valid = false;
+};
+
+struct YuvCodeValues {
+    double y = 0.0;
+    double u = 128.0;
+    double v = 128.0;
+};
+
+YuvRangeScale makeYuvRangeScale(const LdDecodeMetaData::VideoParameters &videoParameters)
+{
+    static constexpr double oneMinusKb = 1.0 - 0.114;
+    static constexpr double oneMinusKr = 1.0 - 0.299;
+    static constexpr double kb = 0.49211104112248356308804691718185;
+    static constexpr double kr = 0.87728321993817866838972487283129;
+
+    YuvRangeScale scale;
+    const double signalRange = static_cast<double>(videoParameters.white16bIre - videoParameters.black16bIre);
+    if (signalRange <= 0.0) {
+        return scale;
+    }
+
+    scale.yScale = 219.0 / signalRange;
+    scale.cbScale = (112.0 / (oneMinusKb * kb)) / signalRange;
+    scale.crScale = (112.0 / (oneMinusKr * kr)) / signalRange;
+    scale.blackLevel = static_cast<double>(videoParameters.black16bIre);
+    scale.valid = true;
+    return scale;
+}
+
+YuvCodeValues convertComponentSampleToYuvCodeValues(double y, double u, double v, const YuvRangeScale &scale)
+{
+    YuvCodeValues codeValues;
+    codeValues.y = ((y - scale.blackLevel) * scale.yScale) + 16.0;
+    codeValues.u = (u * scale.cbScale) + 128.0;
+    codeValues.v = (v * scale.crScale) + 128.0;
+    return codeValues;
+}
+
+bool yuvRangeSettingsMatch(const YuvRangeSettings &settings,
+                           qint32 lumaMin,
+                           qint32 lumaMax,
+                           qint32 chromaMin,
+                           qint32 chromaMax)
+{
+    return settings.lumaMin == lumaMin
+           && settings.lumaMax == lumaMax
+           && settings.chromaMin == chromaMin
+           && settings.chromaMax == chromaMax;
+}
+
 QString backupFilenameWithTimestampFallback(const QString &inputMetadataFilename,
                                             const QString &backupSuffix)
 {
@@ -285,7 +342,8 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
 
 QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
                                 const LdDecodeMetaData::VideoParameters &videoParameters,
-                                const QSize &targetSize)
+                                const QSize &targetSize,
+                                const YuvRangeSettings &settings)
 {
     const qint32 requestedWidth = targetSize.width() > 0 ? targetSize.width() : videoParameters.fieldWidth;
     const qint32 requestedHeight = targetSize.height() > 0 ? targetSize.height() : videoParameters.fieldHeight;
@@ -308,8 +366,8 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
         return renderMessage(QStringLiteral("No YUV range data"));
     }
 
-    double signalRange = static_cast<double>(videoParameters.white16bIre - videoParameters.black16bIre);
-    if (signalRange <= 0.0) {
+    const YuvRangeScale rangeScale = makeYuvRangeScale(videoParameters);
+    if (!rangeScale.valid) {
         return renderMessage(QStringLiteral("Invalid video levels"));
     }
 
@@ -347,23 +405,15 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
         histogramChannel.total++;
     };
 
-    static constexpr double oneMinusKb = 1.0 - 0.114;
-    static constexpr double oneMinusKr = 1.0 - 0.299;
-    static constexpr double kb = 0.49211104112248356308804691718185;
-    static constexpr double kr = 0.87728321993817866838972487283129;
-    const double yScale = 219.0 / signalRange;
-    const double cbScale = (112.0 / (oneMinusKb * kb)) / signalRange;
-    const double crScale = (112.0 / (oneMinusKr * kr)) / signalRange;
-    const double blackLevel = static_cast<double>(videoParameters.black16bIre);
-
     for (qint32 sourceY = sourceYStart; sourceY < sourceYEnd; ++sourceY) {
         const double *yLine = componentFrame.y(sourceY);
         const double *uLine = componentFrame.u(sourceY);
         const double *vLine = componentFrame.v(sourceY);
         for (qint32 sourceX = sourceXStart; sourceX < sourceXEnd; ++sourceX) {
-            addSample(0, ((yLine[sourceX] - blackLevel) * yScale) + 16.0, 16, 235);
-            addSample(1, (uLine[sourceX] * cbScale) + 128.0, 16, 240);
-            addSample(2, (vLine[sourceX] * crScale) + 128.0, 16, 240);
+            const YuvCodeValues codeValues = convertComponentSampleToYuvCodeValues(yLine[sourceX], uLine[sourceX], vLine[sourceX], rangeScale);
+            addSample(0, codeValues.y, settings.lumaMin, settings.lumaMax);
+            addSample(1, codeValues.u, settings.chromaMin, settings.chromaMax);
+            addSample(2, codeValues.v, settings.chromaMin, settings.chromaMax);
         }
     }
 
@@ -413,7 +463,8 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
         const qint32 rowTop = headerTop + headerHeight;
         const QRect plotRect(leftAxisWidth, rowTop, plotWidth, rowHeight);
         const QRect statsRect(plotRect.left(), headerTop, plotRect.width(), headerHeight);
-        const qint32 legalHigh = channel == 0 ? 235 : 240;
+        const qint32 legalLow = channel == 0 ? settings.lumaMin : settings.chromaMin;
+        const qint32 legalHigh = channel == 0 ? settings.lumaMax : settings.chromaMax;
         const HistogramChannel &histogramChannel = channels[static_cast<size_t>(channel)];
 
         const QString statsText = QStringLiteral("below %1 (%2%)  above %3 (%4%)")
@@ -431,12 +482,14 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
                               statsText);
 
         const qint32 lowStartX = binToX(plotRect, 0);
-        const qint32 lowEndX = binToX(plotRect, 15);
+        const qint32 lowEndX = binToX(plotRect, legalLow - 1);
         const qint32 highStartX = binToX(plotRect, legalHigh + 1);
         const qint32 highEndX = binToX(plotRect, 255);
-        scopePainter.fillRect(QRect(lowStartX, plotRect.top(), qMax<qint32>(1, lowEndX - lowStartX + 1), plotRect.height()),
-                              QColor(150, 24, 24, 95));
-        if (highEndX >= highStartX) {
+        if (legalLow > 0) {
+            scopePainter.fillRect(QRect(lowStartX, plotRect.top(), qMax<qint32>(1, lowEndX - lowStartX + 1), plotRect.height()),
+                                  QColor(150, 24, 24, 95));
+        }
+        if (legalHigh < 255 && highEndX >= highStartX) {
             scopePainter.fillRect(QRect(highStartX, plotRect.top(), qMax<qint32>(1, highEndX - highStartX + 1), plotRect.height()),
                                   QColor(150, 24, 24, 95));
         }
@@ -449,7 +502,7 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
         }
 
         scopePainter.setPen(QPen(QColor(215, 215, 215, 210), 1, Qt::DashLine));
-        const qint32 lowX = binToX(plotRect, 16);
+        const qint32 lowX = binToX(plotRect, legalLow);
         const qint32 highX = binToX(plotRect, legalHigh);
         scopePainter.drawLine(lowX, plotRect.top(), lowX, plotRect.bottom());
         scopePainter.drawLine(highX, plotRect.top(), highX, plotRect.bottom());
@@ -471,7 +524,7 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
             const qint32 barHeight = qBound<qint32>(1,
                                                     static_cast<qint32>((std::sqrt(static_cast<double>(binCount)) / maxDensity) * static_cast<double>(plotRect.height() - 2)),
                                                     qMax<qint32>(1, plotRect.height() - 2));
-            const bool outOfRange = bin < 16 || bin > legalHigh;
+            const bool outOfRange = bin < legalLow || bin > legalHigh;
             const QColor barColor = outOfRange ? QColor(255, 72, 72) : channelColors[static_cast<size_t>(channel)];
             scopePainter.fillRect(QRect(binX,
                                          plotRect.bottom() - barHeight,
@@ -488,8 +541,21 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
     const QRect bottomLabelRect(leftAxisWidth, scopeHeight - bottomPadding, plotWidth, bottomPadding);
     scopePainter.drawText(bottomLabelRect,
                           Qt::AlignLeft | Qt::AlignVCenter,
-                          QStringLiteral("8-bit code values; Y legal 16-235, U/V legal 16-240"));
-    const std::array<qint32, 6> bottomValues = { 0, 16, 128, 235, 240, 255 };
+                          QStringLiteral("8-bit code values; Y legal %1-%2, U/V legal %3-%4")
+                              .arg(settings.lumaMin)
+                              .arg(settings.lumaMax)
+                              .arg(settings.chromaMin)
+                              .arg(settings.chromaMax));
+    const std::array<qint32, 8> bottomValues = {
+        0,
+        settings.lumaMin,
+        settings.chromaMin,
+        128,
+        settings.lumaMax,
+        settings.chromaMax,
+        240,
+        255
+    };
     for (const qint32 value : bottomValues) {
         const qint32 x = leftAxisWidth + ((value * qMax<qint32>(1, plotWidth - 1)) / 255);
         scopePainter.drawText(QRect(x - 18, scopeHeight - bottomPadding, 36, qMax<qint32>(12, bottomPadding / 2)),
@@ -499,6 +565,128 @@ QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
 
     scopePainter.end();
     return scopeImage.convertToFormat(QImage::Format_RGB32);
+}
+
+QImage renderYuvRangeOverlayImage(const ComponentFrame &componentFrame,
+                                  const LdDecodeMetaData::VideoParameters &videoParameters,
+                                  const YuvRangeSettings &settings,
+                                  TbcSource::ViewMode renderViewMode,
+                                  bool stretchField,
+                                  qint32 loadedFieldNumber)
+{
+    const qint32 frameWidth = componentFrame.getWidth();
+    const qint32 frameHeight = componentFrame.getHeight();
+    if (frameWidth <= 0 || frameHeight <= 0) {
+        return QImage();
+    }
+    if (renderViewMode == TbcSource::ViewMode::RGB_SCOPE_VIEW) {
+        return QImage();
+    }
+
+    const YuvRangeScale rangeScale = makeYuvRangeScale(videoParameters);
+    if (!rangeScale.valid) {
+        return QImage();
+    }
+
+    qint32 sourceXStart = qBound<qint32>(0, videoParameters.activeVideoStart, frameWidth - 1);
+    qint32 sourceXEnd = qBound<qint32>(sourceXStart + 1, videoParameters.activeVideoEnd, frameWidth);
+    qint32 sourceYStart = qBound<qint32>(0, videoParameters.firstActiveFrameLine, frameHeight - 1);
+    qint32 sourceYEnd = qBound<qint32>(sourceYStart + 1, videoParameters.lastActiveFrameLine, frameHeight);
+
+    if (sourceXEnd <= sourceXStart) {
+        sourceXStart = 0;
+        sourceXEnd = frameWidth;
+    }
+    if (sourceYEnd <= sourceYStart) {
+        sourceYStart = 0;
+        sourceYEnd = frameHeight;
+    }
+
+    QImage overlayImage(frameWidth, frameHeight, QImage::Format_ARGB32);
+    overlayImage.fill(Qt::transparent);
+    const qint32 overlayAlpha = qBound<qint32>(0, settings.overlayAlpha, 255);
+    const QRgb belowColor = qRgba(0, 255, 255, overlayAlpha);
+    const QRgb aboveColor = qRgba(0, 255, 0, overlayAlpha);
+
+    auto sampleOverlayColor = [&](qint32 sourceX, qint32 sourceY) {
+        if (sourceX < sourceXStart || sourceX >= sourceXEnd || sourceY < sourceYStart || sourceY >= sourceYEnd) {
+            return qRgba(0, 0, 0, 0);
+        }
+
+        const double *yLine = componentFrame.y(sourceY);
+        const double *uLine = componentFrame.u(sourceY);
+        const double *vLine = componentFrame.v(sourceY);
+        const YuvCodeValues codeValues = convertComponentSampleToYuvCodeValues(yLine[sourceX], uLine[sourceX], vLine[sourceX], rangeScale);
+        const bool belowRange = codeValues.y < settings.lumaMin
+                                || codeValues.u < settings.chromaMin
+                                || codeValues.v < settings.chromaMin;
+        const bool aboveRange = codeValues.y > settings.lumaMax
+                                || codeValues.u > settings.chromaMax
+                                || codeValues.v > settings.chromaMax;
+        if (aboveRange) {
+            return aboveColor;
+        }
+        return belowRange ? belowColor : qRgba(0, 0, 0, 0);
+    };
+
+    if (renderViewMode == TbcSource::ViewMode::FRAME_VIEW) {
+        for (qint32 sourceY = sourceYStart; sourceY < sourceYEnd; ++sourceY) {
+            QRgb *overlayLine = reinterpret_cast<QRgb *>(overlayImage.scanLine(sourceY));
+            for (qint32 sourceX = sourceXStart; sourceX < sourceXEnd; ++sourceX) {
+                const QRgb overlayColor = sampleOverlayColor(sourceX, sourceY);
+                if (qAlpha(overlayColor) > 0) {
+                    overlayLine[sourceX] = overlayColor;
+                }
+            }
+        }
+        return overlayImage;
+    }
+
+    if (renderViewMode == TbcSource::ViewMode::SPLIT_VIEW) {
+        for (qint32 sourceY = sourceYStart; sourceY < sourceYEnd; ++sourceY) {
+            const qint32 outputY = (sourceY / 2) + (sourceY % 2 == 0 ? 0 : (frameHeight / 2) + 1);
+            if (outputY < 0 || outputY >= frameHeight) {
+                continue;
+            }
+            QRgb *overlayLine = reinterpret_cast<QRgb *>(overlayImage.scanLine(outputY));
+            for (qint32 sourceX = sourceXStart; sourceX < sourceXEnd; ++sourceX) {
+                const QRgb overlayColor = sampleOverlayColor(sourceX, sourceY);
+                if (qAlpha(overlayColor) > 0) {
+                    overlayLine[sourceX] = overlayColor;
+                }
+            }
+        }
+        return overlayImage;
+    }
+
+    const qint32 fieldHeight = videoParameters.fieldHeight;
+    const qint32 startOffset = stretchField ? 0 : frameHeight / 4;
+    const qint32 outputHeight = stretchField ? frameHeight : fieldHeight;
+    qint32 fieldY = loadedFieldNumber % 2 ? 0 : 1;
+    qint32 maxFieldY = frameHeight - 1;
+    if (maxFieldY >= 0 && (maxFieldY % 2) != (fieldY % 2)) {
+        maxFieldY -= 1;
+    }
+
+    for (qint32 outputYLocal = 0; outputYLocal < outputHeight; ++outputYLocal) {
+        const qint32 outputY = outputYLocal + startOffset;
+        if (outputY >= 0 && outputY < frameHeight) {
+            const qint32 sourceY = qBound<qint32>(0, fieldY, qMax<qint32>(0, maxFieldY));
+            QRgb *overlayLine = reinterpret_cast<QRgb *>(overlayImage.scanLine(outputY));
+            for (qint32 sourceX = sourceXStart; sourceX < sourceXEnd; ++sourceX) {
+                const QRgb overlayColor = sampleOverlayColor(sourceX, sourceY);
+                if (qAlpha(overlayColor) > 0) {
+                    overlayLine[sourceX] = overlayColor;
+                }
+            }
+        }
+
+        if (!stretchField || outputYLocal % 2 != 0) {
+            fieldY += 2;
+        }
+    }
+
+    return overlayImage;
 }
 }
 
@@ -947,21 +1135,63 @@ QImage TbcSource::getRgbScopeImage(const QSize &targetSize)
     return rgbScopeCache;
 }
 
-QImage TbcSource::getYuvRangeScopeImage(const QSize &targetSize)
+QImage TbcSource::getYuvRangeScopeImage(const QSize &targetSize, const YuvRangeSettings &settings)
 {
     if (metadataOnly) return QImage();
     if (loadedFrameNumber == -1 && loadedFieldNumber == -1) return QImage();
 
     const QSize normalizedTargetSize = targetSize.expandedTo(QSize(1, 1));
-    if (yuvRangeScopeCacheValid && yuvRangeScopeCacheSize == normalizedTargetSize) {
+    if (yuvRangeScopeCacheValid
+        && yuvRangeScopeCacheSize == normalizedTargetSize
+        && yuvRangeSettingsMatch(settings,
+                                 yuvRangeScopeCacheLumaMin,
+                                 yuvRangeScopeCacheLumaMax,
+                                 yuvRangeScopeCacheChromaMin,
+                                 yuvRangeScopeCacheChromaMax)) {
         return yuvRangeScopeCache;
     }
 
     const ComponentFrame &componentFrame = getComponentFrame();
-    yuvRangeScopeCache = renderYuvRangeScopeImage(componentFrame, ldDecodeMetaData.getVideoParameters(), normalizedTargetSize);
+    yuvRangeScopeCache = renderYuvRangeScopeImage(componentFrame, ldDecodeMetaData.getVideoParameters(), normalizedTargetSize, settings);
     yuvRangeScopeCacheValid = true;
     yuvRangeScopeCacheSize = normalizedTargetSize;
+    yuvRangeScopeCacheLumaMin = settings.lumaMin;
+    yuvRangeScopeCacheLumaMax = settings.lumaMax;
+    yuvRangeScopeCacheChromaMin = settings.chromaMin;
+    yuvRangeScopeCacheChromaMax = settings.chromaMax;
     return yuvRangeScopeCache;
+}
+
+QImage TbcSource::getYuvRangeOverlayImage(const YuvRangeSettings &settings)
+{
+    if (metadataOnly) return QImage();
+    if (loadedFrameNumber == -1 && loadedFieldNumber == -1) return QImage();
+
+    if (yuvRangeOverlayCacheValid
+        && yuvRangeSettingsMatch(settings,
+                                 yuvRangeOverlayCacheLumaMin,
+                                 yuvRangeOverlayCacheLumaMax,
+                                 yuvRangeOverlayCacheChromaMin,
+                                 yuvRangeOverlayCacheChromaMax)
+        && yuvRangeOverlayCacheAlpha == settings.overlayAlpha
+        && yuvRangeOverlayCacheViewMode == viewMode
+        && yuvRangeOverlayCacheStretchField == stretchFieldOn
+        && yuvRangeOverlayCacheFieldNumber == loadedFieldNumber) {
+        return yuvRangeOverlayCache;
+    }
+
+    const ComponentFrame &componentFrame = getComponentFrame();
+    yuvRangeOverlayCache = renderYuvRangeOverlayImage(componentFrame, ldDecodeMetaData.getVideoParameters(), settings, viewMode, stretchFieldOn, loadedFieldNumber);
+    yuvRangeOverlayCacheValid = true;
+    yuvRangeOverlayCacheLumaMin = settings.lumaMin;
+    yuvRangeOverlayCacheLumaMax = settings.lumaMax;
+    yuvRangeOverlayCacheChromaMin = settings.chromaMin;
+    yuvRangeOverlayCacheChromaMax = settings.chromaMax;
+    yuvRangeOverlayCacheAlpha = settings.overlayAlpha;
+    yuvRangeOverlayCacheViewMode = viewMode;
+    yuvRangeOverlayCacheStretchField = stretchFieldOn;
+    yuvRangeOverlayCacheFieldNumber = loadedFieldNumber;
+    return yuvRangeOverlayCache;
 }
 
 // Method to get the number of available frames
@@ -1546,6 +1776,20 @@ void TbcSource::resetState()
     yuvRangeScopeCache = QImage();
     yuvRangeScopeCacheValid = false;
     yuvRangeScopeCacheSize = QSize();
+    yuvRangeScopeCacheLumaMin = 16;
+    yuvRangeScopeCacheLumaMax = 235;
+    yuvRangeScopeCacheChromaMin = 16;
+    yuvRangeScopeCacheChromaMax = 240;
+    yuvRangeOverlayCache = QImage();
+    yuvRangeOverlayCacheValid = false;
+    yuvRangeOverlayCacheLumaMin = 16;
+    yuvRangeOverlayCacheLumaMax = 235;
+    yuvRangeOverlayCacheChromaMin = 16;
+    yuvRangeOverlayCacheChromaMax = 240;
+    yuvRangeOverlayCacheAlpha = 180;
+    yuvRangeOverlayCacheViewMode = ViewMode::FRAME_VIEW;
+    yuvRangeOverlayCacheStretchField = false;
+    yuvRangeOverlayCacheFieldNumber = -1;
     cache = QImage();
     cacheValid = false;
 }
@@ -1561,6 +1805,7 @@ void TbcSource::invalidateImageCache()
     rgbScopeCacheSize = QSize();
     yuvRangeScopeCacheValid = false;
     yuvRangeScopeCacheSize = QSize();
+    yuvRangeOverlayCacheValid = false;
     cacheValid = false;
 }
 

--- a/src/ld-analyse/tbcsource.cpp
+++ b/src/ld-analyse/tbcsource.cpp
@@ -282,6 +282,224 @@ QImage renderRgbParadeScopeImage(const QVector<QRgb> &rgbData,
     scopePainter.end();
     return scopeImage.convertToFormat(QImage::Format_RGB32);
 }
+
+QImage renderYuvRangeScopeImage(const ComponentFrame &componentFrame,
+                                const LdDecodeMetaData::VideoParameters &videoParameters,
+                                const QSize &targetSize)
+{
+    const qint32 requestedWidth = targetSize.width() > 0 ? targetSize.width() : videoParameters.fieldWidth;
+    const qint32 requestedHeight = targetSize.height() > 0 ? targetSize.height() : videoParameters.fieldHeight;
+    const qint32 scopeWidth = qBound<qint32>(320, requestedWidth, 2048);
+    const qint32 scopeHeight = qBound<qint32>(220, requestedHeight, 1536);
+
+    auto renderMessage = [&](const QString &message) {
+        QImage messageImage(scopeWidth, scopeHeight, QImage::Format_RGB32);
+        messageImage.fill(Qt::black);
+        QPainter messagePainter(&messageImage);
+        messagePainter.setPen(QColor(210, 210, 210));
+        messagePainter.drawText(messageImage.rect(), Qt::AlignCenter, message);
+        messagePainter.end();
+        return messageImage;
+    };
+
+    const qint32 frameWidth = componentFrame.getWidth();
+    const qint32 frameHeight = componentFrame.getHeight();
+    if (frameWidth <= 0 || frameHeight <= 0) {
+        return renderMessage(QStringLiteral("No YUV range data"));
+    }
+
+    double signalRange = static_cast<double>(videoParameters.white16bIre - videoParameters.black16bIre);
+    if (signalRange <= 0.0) {
+        return renderMessage(QStringLiteral("Invalid video levels"));
+    }
+
+    qint32 sourceXStart = qBound<qint32>(0, videoParameters.activeVideoStart, frameWidth - 1);
+    qint32 sourceXEnd = qBound<qint32>(sourceXStart + 1, videoParameters.activeVideoEnd, frameWidth);
+    qint32 sourceYStart = qBound<qint32>(0, videoParameters.firstActiveFrameLine, frameHeight - 1);
+    qint32 sourceYEnd = qBound<qint32>(sourceYStart + 1, videoParameters.lastActiveFrameLine, frameHeight);
+
+    if (sourceXEnd <= sourceXStart) {
+        sourceXStart = 0;
+        sourceXEnd = frameWidth;
+    }
+    if (sourceYEnd <= sourceYStart) {
+        sourceYStart = 0;
+        sourceYEnd = frameHeight;
+    }
+
+    struct HistogramChannel {
+        std::array<quint64, 256> bins = {};
+        quint64 below = 0;
+        quint64 above = 0;
+        quint64 total = 0;
+    };
+    std::array<HistogramChannel, 3> channels;
+
+    auto addSample = [&](qint32 channel, double codeValue, qint32 legalLow, qint32 legalHigh) {
+        HistogramChannel &histogramChannel = channels[static_cast<size_t>(channel)];
+        if (codeValue < static_cast<double>(legalLow)) {
+            histogramChannel.below++;
+        } else if (codeValue > static_cast<double>(legalHigh)) {
+            histogramChannel.above++;
+        }
+        const qint32 bin = qBound<qint32>(0, static_cast<qint32>(std::floor(codeValue + 0.5)), 255);
+        histogramChannel.bins[static_cast<size_t>(bin)]++;
+        histogramChannel.total++;
+    };
+
+    static constexpr double oneMinusKb = 1.0 - 0.114;
+    static constexpr double oneMinusKr = 1.0 - 0.299;
+    static constexpr double kb = 0.49211104112248356308804691718185;
+    static constexpr double kr = 0.87728321993817866838972487283129;
+    const double yScale = 219.0 / signalRange;
+    const double cbScale = (112.0 / (oneMinusKb * kb)) / signalRange;
+    const double crScale = (112.0 / (oneMinusKr * kr)) / signalRange;
+    const double blackLevel = static_cast<double>(videoParameters.black16bIre);
+
+    for (qint32 sourceY = sourceYStart; sourceY < sourceYEnd; ++sourceY) {
+        const double *yLine = componentFrame.y(sourceY);
+        const double *uLine = componentFrame.u(sourceY);
+        const double *vLine = componentFrame.v(sourceY);
+        for (qint32 sourceX = sourceXStart; sourceX < sourceXEnd; ++sourceX) {
+            addSample(0, ((yLine[sourceX] - blackLevel) * yScale) + 16.0, 16, 235);
+            addSample(1, (uLine[sourceX] * cbScale) + 128.0, 16, 240);
+            addSample(2, (vLine[sourceX] * crScale) + 128.0, 16, 240);
+        }
+    }
+
+    QImage scopeImage(scopeWidth, scopeHeight, QImage::Format_RGB32);
+    scopeImage.fill(Qt::black);
+
+    const qint32 leftAxisWidth = qBound<qint32>(34, scopeWidth / 12, 76);
+    const qint32 rightPadding = qBound<qint32>(8, scopeWidth / 64, 18);
+    const qint32 topPadding = qBound<qint32>(6, scopeHeight / 60, 16);
+    const qint32 bottomPadding = qBound<qint32>(28, scopeHeight / 11, 62);
+    const qint32 rowGap = qBound<qint32>(6, scopeHeight / 55, 18);
+    const qint32 headerHeight = qBound<qint32>(18, scopeHeight / 30, 30);
+    const qint32 availableHeight = qMax<qint32>(24, scopeHeight - topPadding - bottomPadding - (rowGap * 2) - (headerHeight * 3));
+    const qint32 rowHeight = qMax<qint32>(1, availableHeight / 3);
+    const qint32 plotWidth = qMax<qint32>(1, scopeWidth - leftAxisWidth - rightPadding);
+
+    auto binToX = [&](const QRect &plotRect, qint32 bin) {
+        return plotRect.left() + ((qBound<qint32>(0, bin, 255) * qMax<qint32>(1, plotRect.width() - 1)) / 255);
+    };
+    auto percentText = [](quint64 count, quint64 total) {
+        if (total == 0) {
+            return QStringLiteral("0.000");
+        }
+        const double percent = (static_cast<double>(count) * 100.0) / static_cast<double>(total);
+        return QString::number(percent, 'f', percent < 1.0 ? 3 : 2);
+    };
+
+    QPainter scopePainter(&scopeImage);
+    scopePainter.setRenderHint(QPainter::Antialiasing, false);
+    QFont axisFont = scopePainter.font();
+    axisFont.setPointSize(qMax<qint32>(7, scopeHeight / 46));
+    scopePainter.setFont(axisFont);
+
+    const std::array<QString, 3> labels = {
+        QStringLiteral("Y"),
+        QStringLiteral("U"),
+        QStringLiteral("V")
+    };
+    const std::array<QColor, 3> channelColors = {
+        QColor(245, 245, 245),
+        QColor(96, 180, 255),
+        QColor(255, 118, 180)
+    };
+
+    for (qint32 channel = 0; channel < 3; ++channel) {
+        const qint32 headerTop = topPadding + (channel * (headerHeight + rowHeight + rowGap));
+        const qint32 rowTop = headerTop + headerHeight;
+        const QRect plotRect(leftAxisWidth, rowTop, plotWidth, rowHeight);
+        const QRect statsRect(plotRect.left(), headerTop, plotRect.width(), headerHeight);
+        const qint32 legalHigh = channel == 0 ? 235 : 240;
+        const HistogramChannel &histogramChannel = channels[static_cast<size_t>(channel)];
+
+        const QString statsText = QStringLiteral("below %1 (%2%)  above %3 (%4%)")
+            .arg(histogramChannel.below)
+            .arg(percentText(histogramChannel.below, histogramChannel.total))
+            .arg(histogramChannel.above)
+            .arg(percentText(histogramChannel.above, histogramChannel.total));
+        scopePainter.setPen(channelColors[static_cast<size_t>(channel)]);
+        scopePainter.drawText(QRect(2, headerTop, leftAxisWidth - 6, headerHeight),
+                              Qt::AlignRight | Qt::AlignVCenter,
+                              labels[static_cast<size_t>(channel)]);
+        scopePainter.setPen(QColor(220, 220, 220));
+        scopePainter.drawText(statsRect,
+                              Qt::AlignLeft | Qt::AlignVCenter,
+                              statsText);
+
+        const qint32 lowStartX = binToX(plotRect, 0);
+        const qint32 lowEndX = binToX(plotRect, 15);
+        const qint32 highStartX = binToX(plotRect, legalHigh + 1);
+        const qint32 highEndX = binToX(plotRect, 255);
+        scopePainter.fillRect(QRect(lowStartX, plotRect.top(), qMax<qint32>(1, lowEndX - lowStartX + 1), plotRect.height()),
+                              QColor(150, 24, 24, 95));
+        if (highEndX >= highStartX) {
+            scopePainter.fillRect(QRect(highStartX, plotRect.top(), qMax<qint32>(1, highEndX - highStartX + 1), plotRect.height()),
+                                  QColor(150, 24, 24, 95));
+        }
+
+        scopePainter.setPen(QPen(QColor(80, 80, 80), 1));
+        const std::array<qint32, 5> guideValues = { 0, 64, 128, 192, 255 };
+        for (const qint32 guideValue : guideValues) {
+            const qint32 guideX = binToX(plotRect, guideValue);
+            scopePainter.drawLine(guideX, plotRect.top(), guideX, plotRect.bottom());
+        }
+
+        scopePainter.setPen(QPen(QColor(215, 215, 215, 210), 1, Qt::DashLine));
+        const qint32 lowX = binToX(plotRect, 16);
+        const qint32 highX = binToX(plotRect, legalHigh);
+        scopePainter.drawLine(lowX, plotRect.top(), lowX, plotRect.bottom());
+        scopePainter.drawLine(highX, plotRect.top(), highX, plotRect.bottom());
+
+        quint64 maxBin = 0;
+        for (const quint64 binCount : histogramChannel.bins) {
+            maxBin = qMax(maxBin, binCount);
+        }
+        const double maxDensity = maxBin > 0 ? std::sqrt(static_cast<double>(maxBin)) : 1.0;
+        for (qint32 bin = 0; bin < 256; ++bin) {
+            const quint64 binCount = histogramChannel.bins[static_cast<size_t>(bin)];
+            if (binCount == 0) {
+                continue;
+            }
+
+            const qint32 binX = binToX(plotRect, bin);
+            const qint32 nextBinX = binToX(plotRect, qMin<qint32>(255, bin + 1));
+            const qint32 barWidth = qMax<qint32>(1, nextBinX - binX + 1);
+            const qint32 barHeight = qBound<qint32>(1,
+                                                    static_cast<qint32>((std::sqrt(static_cast<double>(binCount)) / maxDensity) * static_cast<double>(plotRect.height() - 2)),
+                                                    qMax<qint32>(1, plotRect.height() - 2));
+            const bool outOfRange = bin < 16 || bin > legalHigh;
+            const QColor barColor = outOfRange ? QColor(255, 72, 72) : channelColors[static_cast<size_t>(channel)];
+            scopePainter.fillRect(QRect(binX,
+                                         plotRect.bottom() - barHeight,
+                                         barWidth,
+                                         barHeight),
+                                  barColor);
+        }
+
+        scopePainter.setPen(QPen(QColor(150, 150, 150), 1));
+        scopePainter.drawRect(plotRect.adjusted(0, 0, -1, -1));
+    }
+
+    scopePainter.setPen(QColor(170, 170, 170));
+    const QRect bottomLabelRect(leftAxisWidth, scopeHeight - bottomPadding, plotWidth, bottomPadding);
+    scopePainter.drawText(bottomLabelRect,
+                          Qt::AlignLeft | Qt::AlignVCenter,
+                          QStringLiteral("8-bit code values; Y legal 16-235, U/V legal 16-240"));
+    const std::array<qint32, 6> bottomValues = { 0, 16, 128, 235, 240, 255 };
+    for (const qint32 value : bottomValues) {
+        const qint32 x = leftAxisWidth + ((value * qMax<qint32>(1, plotWidth - 1)) / 255);
+        scopePainter.drawText(QRect(x - 18, scopeHeight - bottomPadding, 36, qMax<qint32>(12, bottomPadding / 2)),
+                              Qt::AlignHCenter | Qt::AlignTop,
+                              QString::number(value));
+    }
+
+    scopePainter.end();
+    return scopeImage.convertToFormat(QImage::Format_RGB32);
+}
 }
 
 TbcSource::TbcSource(QObject *parent) : QObject(parent)
@@ -727,6 +945,23 @@ QImage TbcSource::getRgbScopeImage(const QSize &targetSize)
     rgbScopeCacheValid = true;
     rgbScopeCacheSize = normalizedTargetSize;
     return rgbScopeCache;
+}
+
+QImage TbcSource::getYuvRangeScopeImage(const QSize &targetSize)
+{
+    if (metadataOnly) return QImage();
+    if (loadedFrameNumber == -1 && loadedFieldNumber == -1) return QImage();
+
+    const QSize normalizedTargetSize = targetSize.expandedTo(QSize(1, 1));
+    if (yuvRangeScopeCacheValid && yuvRangeScopeCacheSize == normalizedTargetSize) {
+        return yuvRangeScopeCache;
+    }
+
+    const ComponentFrame &componentFrame = getComponentFrame();
+    yuvRangeScopeCache = renderYuvRangeScopeImage(componentFrame, ldDecodeMetaData.getVideoParameters(), normalizedTargetSize);
+    yuvRangeScopeCacheValid = true;
+    yuvRangeScopeCacheSize = normalizedTargetSize;
+    return yuvRangeScopeCache;
 }
 
 // Method to get the number of available frames
@@ -1308,6 +1543,9 @@ void TbcSource::resetState()
     rgbScopeCache = QImage();
     rgbScopeCacheValid = false;
     rgbScopeCacheSize = QSize();
+    yuvRangeScopeCache = QImage();
+    yuvRangeScopeCacheValid = false;
+    yuvRangeScopeCacheSize = QSize();
     cache = QImage();
     cacheValid = false;
 }
@@ -1321,6 +1559,8 @@ void TbcSource::invalidateImageCache()
     decodedFrameValid = false;
     rgbScopeCacheValid = false;
     rgbScopeCacheSize = QSize();
+    yuvRangeScopeCacheValid = false;
+    yuvRangeScopeCacheSize = QSize();
     cacheValid = false;
 }
 

--- a/src/ld-analyse/tbcsource.h
+++ b/src/ld-analyse/tbcsource.h
@@ -33,6 +33,8 @@
 #include "comb.h"
 #include "monodecoder.h"
 
+struct YuvRangeSettings;
+
 class TbcSource : public QObject
 {
     Q_OBJECT
@@ -129,7 +131,8 @@ public:
 
     QImage getImage();
     QImage getRgbScopeImage(const QSize &targetSize = QSize());
-    QImage getYuvRangeScopeImage(const QSize &targetSize = QSize());
+    QImage getYuvRangeScopeImage(const QSize &targetSize, const YuvRangeSettings &settings);
+    QImage getYuvRangeOverlayImage(const YuvRangeSettings &settings);
     qint32 getNumberOfFrames() const;
     qint32 getNumberOfFields() const;
     bool getIsWidescreen() const;
@@ -254,6 +257,20 @@ private:
     QImage yuvRangeScopeCache;
     bool yuvRangeScopeCacheValid;
     QSize yuvRangeScopeCacheSize;
+    qint32 yuvRangeScopeCacheLumaMin;
+    qint32 yuvRangeScopeCacheLumaMax;
+    qint32 yuvRangeScopeCacheChromaMin;
+    qint32 yuvRangeScopeCacheChromaMax;
+    QImage yuvRangeOverlayCache;
+    bool yuvRangeOverlayCacheValid;
+    qint32 yuvRangeOverlayCacheLumaMin;
+    qint32 yuvRangeOverlayCacheLumaMax;
+    qint32 yuvRangeOverlayCacheChromaMin;
+    qint32 yuvRangeOverlayCacheChromaMax;
+    qint32 yuvRangeOverlayCacheAlpha;
+    ViewMode yuvRangeOverlayCacheViewMode;
+    bool yuvRangeOverlayCacheStretchField;
+    qint32 yuvRangeOverlayCacheFieldNumber;
 
     // Chroma decoder configuration
     PalColour::Configuration palConfiguration;

--- a/src/ld-analyse/tbcsource.h
+++ b/src/ld-analyse/tbcsource.h
@@ -129,6 +129,7 @@ public:
 
     QImage getImage();
     QImage getRgbScopeImage(const QSize &targetSize = QSize());
+    QImage getYuvRangeScopeImage(const QSize &targetSize = QSize());
     qint32 getNumberOfFrames() const;
     qint32 getNumberOfFields() const;
     bool getIsWidescreen() const;
@@ -250,6 +251,9 @@ private:
     QImage rgbScopeCache;
     bool rgbScopeCacheValid;
     QSize rgbScopeCacheSize;
+    QImage yuvRangeScopeCache;
+    bool yuvRangeScopeCacheValid;
+    QSize yuvRangeScopeCacheSize;
 
     // Chroma decoder configuration
     PalColour::Configuration palConfiguration;

--- a/src/ld-analyse/yuvrangedialog.cpp
+++ b/src/ld-analyse/yuvrangedialog.cpp
@@ -9,10 +9,15 @@
 
 #include "yuvrangedialog.h"
 
+#include <QGridLayout>
 #include <QLabel>
 #include <QPixmap>
+#include <QPushButton>
 #include <QResizeEvent>
+#include <QSignalBlocker>
 #include <QSizePolicy>
+#include <QSlider>
+#include <QSpinBox>
 #include <QVBoxLayout>
 
 YuvRangeDialog::YuvRangeDialog(QWidget *parent)
@@ -25,14 +30,94 @@ YuvRangeDialog::YuvRangeDialog(QWidget *parent)
 
     auto *mainLayout = new QVBoxLayout(this);
     mainLayout->setContentsMargins(6, 6, 6, 6);
-    mainLayout->setSpacing(0);
+    mainLayout->setSpacing(6);
 
     scopeLabel_ = new QLabel(this);
     scopeLabel_->setAlignment(Qt::AlignCenter);
-    scopeLabel_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    scopeLabel_->setMinimumSize(1, 1);
+    scopeLabel_->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
     scopeLabel_->setScaledContents(false);
     scopeLabel_->setText(tr("No YUV range data"));
     mainLayout->addWidget(scopeLabel_);
+
+    auto *controlsLayout = new QGridLayout();
+    controlsLayout->setContentsMargins(0, 0, 0, 0);
+    controlsLayout->setHorizontalSpacing(6);
+    controlsLayout->setVerticalSpacing(4);
+
+    auto makeSpinBox = [this](qint32 value) {
+        auto *spinBox = new QSpinBox(this);
+        spinBox->setRange(0, 255);
+        spinBox->setValue(value);
+        spinBox->setKeyboardTracking(false);
+        return spinBox;
+    };
+
+    lumaMinSpinBox_ = makeSpinBox(16);
+    lumaMaxSpinBox_ = makeSpinBox(235);
+    chromaMinSpinBox_ = makeSpinBox(16);
+    chromaMaxSpinBox_ = makeSpinBox(240);
+
+    overlayButton_ = new QPushButton(tr("Overlay Off"), this);
+    overlayButton_->setCheckable(true);
+    overlayButton_->setChecked(false);
+    overlayAlphaSlider_ = new QSlider(Qt::Horizontal, this);
+    overlayAlphaSlider_->setRange(0, 255);
+    overlayAlphaSlider_->setValue(180);
+    overlayAlphaSlider_->setMinimumWidth(120);
+    overlayAlphaValueLabel_ = new QLabel(QString::number(overlayAlphaSlider_->value()), this);
+    overlayAlphaValueLabel_->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    overlayAlphaValueLabel_->setMinimumWidth(28);
+
+    controlsLayout->addWidget(new QLabel(tr("Luma Min"), this), 0, 0);
+    controlsLayout->addWidget(lumaMinSpinBox_, 0, 1);
+    controlsLayout->addWidget(new QLabel(tr("Luma Max"), this), 0, 2);
+    controlsLayout->addWidget(lumaMaxSpinBox_, 0, 3);
+    controlsLayout->addWidget(new QLabel(tr("Chroma Min"), this), 0, 4);
+    controlsLayout->addWidget(chromaMinSpinBox_, 0, 5);
+    controlsLayout->addWidget(new QLabel(tr("Chroma Max"), this), 0, 6);
+    controlsLayout->addWidget(chromaMaxSpinBox_, 0, 7);
+    controlsLayout->addWidget(overlayButton_, 1, 0, 1, 2);
+    controlsLayout->addWidget(new QLabel(tr("Overlay Alpha"), this), 1, 2);
+    controlsLayout->addWidget(overlayAlphaSlider_, 1, 3, 1, 4);
+    controlsLayout->addWidget(overlayAlphaValueLabel_, 1, 7);
+    controlsLayout->setColumnStretch(8, 1);
+    mainLayout->addLayout(controlsLayout);
+
+    connect(lumaMinSpinBox_, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
+        if (lumaMaxSpinBox_ && value > lumaMaxSpinBox_->value()) {
+            setSpinBoxValueWithoutSignals(lumaMaxSpinBox_, value);
+        }
+        emitSettingsChanged();
+    });
+    connect(lumaMaxSpinBox_, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
+        if (lumaMinSpinBox_ && value < lumaMinSpinBox_->value()) {
+            setSpinBoxValueWithoutSignals(lumaMinSpinBox_, value);
+        }
+        emitSettingsChanged();
+    });
+    connect(chromaMinSpinBox_, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
+        if (chromaMaxSpinBox_ && value > chromaMaxSpinBox_->value()) {
+            setSpinBoxValueWithoutSignals(chromaMaxSpinBox_, value);
+        }
+        emitSettingsChanged();
+    });
+    connect(chromaMaxSpinBox_, QOverload<int>::of(&QSpinBox::valueChanged), this, [this](int value) {
+        if (chromaMinSpinBox_ && value < chromaMinSpinBox_->value()) {
+            setSpinBoxValueWithoutSignals(chromaMinSpinBox_, value);
+        }
+        emitSettingsChanged();
+    });
+    connect(overlayButton_, &QPushButton::toggled, this, [this](bool checked) {
+        overlayButton_->setText(checked ? tr("Overlay On") : tr("Overlay Off"));
+        emitSettingsChanged();
+    });
+    connect(overlayAlphaSlider_, &QSlider::valueChanged, this, [this](int value) {
+        if (overlayAlphaValueLabel_) {
+            overlayAlphaValueLabel_->setText(QString::number(value));
+        }
+        emitSettingsChanged();
+    });
 }
 
 void YuvRangeDialog::showScopeImage(const QImage &scopeImage)
@@ -49,11 +134,38 @@ QSize YuvRangeDialog::scopeRenderTargetSize() const
     return size().expandedTo(QSize(1, 1));
 }
 
+YuvRangeSettings YuvRangeDialog::settings() const
+{
+    YuvRangeSettings currentSettings;
+    currentSettings.lumaMin = lumaMinSpinBox_ ? lumaMinSpinBox_->value() : currentSettings.lumaMin;
+    currentSettings.lumaMax = lumaMaxSpinBox_ ? lumaMaxSpinBox_->value() : currentSettings.lumaMax;
+    currentSettings.chromaMin = chromaMinSpinBox_ ? chromaMinSpinBox_->value() : currentSettings.chromaMin;
+    currentSettings.chromaMax = chromaMaxSpinBox_ ? chromaMaxSpinBox_->value() : currentSettings.chromaMax;
+    currentSettings.overlayAlpha = overlayAlphaSlider_ ? overlayAlphaSlider_->value() : currentSettings.overlayAlpha;
+    currentSettings.overlayEnabled = overlayButton_ ? overlayButton_->isChecked() : currentSettings.overlayEnabled;
+    return currentSettings;
+}
+
 void YuvRangeDialog::resizeEvent(QResizeEvent *event)
 {
     QDialog::resizeEvent(event);
     updateScopeLabelPixmap();
     emit renderTargetSizeChanged(scopeRenderTargetSize());
+}
+
+void YuvRangeDialog::setSpinBoxValueWithoutSignals(QSpinBox *spinBox, qint32 value)
+{
+    if (!spinBox) {
+        return;
+    }
+
+    const QSignalBlocker blocker(spinBox);
+    spinBox->setValue(value);
+}
+
+void YuvRangeDialog::emitSettingsChanged()
+{
+    emit settingsChanged(settings());
 }
 
 void YuvRangeDialog::updateScopeLabelPixmap()

--- a/src/ld-analyse/yuvrangedialog.cpp
+++ b/src/ld-analyse/yuvrangedialog.cpp
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * yuvrangedialog.cpp
+ * ld-analyse - TBC output analysis GUI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This file is part of ld-decode-tools.
+ ******************************************************************************/
+
+#include "yuvrangedialog.h"
+
+#include <QLabel>
+#include <QPixmap>
+#include <QResizeEvent>
+#include <QSizePolicy>
+#include <QVBoxLayout>
+
+YuvRangeDialog::YuvRangeDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("YUV Range"));
+    setWindowFlags(Qt::Window);
+    setModal(false);
+    resize(960, 540);
+
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(6, 6, 6, 6);
+    mainLayout->setSpacing(0);
+
+    scopeLabel_ = new QLabel(this);
+    scopeLabel_->setAlignment(Qt::AlignCenter);
+    scopeLabel_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    scopeLabel_->setScaledContents(false);
+    scopeLabel_->setText(tr("No YUV range data"));
+    mainLayout->addWidget(scopeLabel_);
+}
+
+void YuvRangeDialog::showScopeImage(const QImage &scopeImage)
+{
+    cachedScopeImage_ = scopeImage;
+    updateScopeLabelPixmap();
+}
+
+QSize YuvRangeDialog::scopeRenderTargetSize() const
+{
+    if (scopeLabel_) {
+        return scopeLabel_->size().expandedTo(QSize(1, 1));
+    }
+    return size().expandedTo(QSize(1, 1));
+}
+
+void YuvRangeDialog::resizeEvent(QResizeEvent *event)
+{
+    QDialog::resizeEvent(event);
+    updateScopeLabelPixmap();
+    emit renderTargetSizeChanged(scopeRenderTargetSize());
+}
+
+void YuvRangeDialog::updateScopeLabelPixmap()
+{
+    if (!scopeLabel_) {
+        return;
+    }
+
+    if (cachedScopeImage_.isNull()) {
+        scopeLabel_->setPixmap(QPixmap());
+        scopeLabel_->setText(tr("No YUV range data"));
+        return;
+    }
+
+    const QSize targetSize = scopeLabel_->size().expandedTo(QSize(1, 1));
+    const QPixmap pixmap = QPixmap::fromImage(cachedScopeImage_).scaled(
+        targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scopeLabel_->setText(QString());
+    scopeLabel_->setPixmap(pixmap);
+}

--- a/src/ld-analyse/yuvrangedialog.h
+++ b/src/ld-analyse/yuvrangedialog.h
@@ -13,9 +13,22 @@
 #include <QDialog>
 #include <QImage>
 #include <QSize>
+#include <QtGlobal>
 
 class QLabel;
+class QPushButton;
 class QResizeEvent;
+class QSlider;
+class QSpinBox;
+
+struct YuvRangeSettings {
+    qint32 lumaMin = 16;
+    qint32 lumaMax = 235;
+    qint32 chromaMin = 16;
+    qint32 chromaMax = 240;
+    qint32 overlayAlpha = 180;
+    bool overlayEnabled = false;
+};
 
 class YuvRangeDialog : public QDialog
 {
@@ -27,18 +40,29 @@ public:
 
     void showScopeImage(const QImage &scopeImage);
     QSize scopeRenderTargetSize() const;
+    YuvRangeSettings settings() const;
 
 signals:
     void renderTargetSizeChanged(const QSize &targetSize);
+    void settingsChanged(const YuvRangeSettings &settings);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
 
 private:
     void updateScopeLabelPixmap();
+    void setSpinBoxValueWithoutSignals(QSpinBox *spinBox, qint32 value);
+    void emitSettingsChanged();
 
     QLabel *scopeLabel_ = nullptr;
     QImage cachedScopeImage_;
+    QSpinBox *lumaMinSpinBox_ = nullptr;
+    QSpinBox *lumaMaxSpinBox_ = nullptr;
+    QSpinBox *chromaMinSpinBox_ = nullptr;
+    QSpinBox *chromaMaxSpinBox_ = nullptr;
+    QPushButton *overlayButton_ = nullptr;
+    QSlider *overlayAlphaSlider_ = nullptr;
+    QLabel *overlayAlphaValueLabel_ = nullptr;
 };
 
 #endif // YUVRANGEDIALOG_H

--- a/src/ld-analyse/yuvrangedialog.h
+++ b/src/ld-analyse/yuvrangedialog.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * yuvrangedialog.h
+ * ld-analyse - TBC output analysis GUI
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This file is part of ld-decode-tools.
+ ******************************************************************************/
+
+#ifndef YUVRANGEDIALOG_H
+#define YUVRANGEDIALOG_H
+
+#include <QDialog>
+#include <QImage>
+#include <QSize>
+
+class QLabel;
+class QResizeEvent;
+
+class YuvRangeDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit YuvRangeDialog(QWidget *parent = nullptr);
+    ~YuvRangeDialog() override = default;
+
+    void showScopeImage(const QImage &scopeImage);
+    QSize scopeRenderTargetSize() const;
+
+signals:
+    void renderTargetSizeChanged(const QSize &targetSize);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    void updateScopeLabelPixmap();
+
+    QLabel *scopeLabel_ = nullptr;
+    QImage cachedScopeImage_;
+};
+
+#endif // YUVRANGEDIALOG_H


### PR DESCRIPTION
<img width="1200" height="928" alt="image" src="https://github.com/user-attachments/assets/88cb2357-f050-46b3-ab55-53e7b65836fa" />

* Fixed RGB scope not being able to be resized to a smaller size after resizing it to a larger size
* Added `Scopes -> YUV range...` which shows a Y/U/V histogram and highlights the parts that are outside of Limited Range (16-235 on an 8-bit scale)
* Optional overlay with adjustable opacity which highlights all pixels that are below (cyan) or above (green) Limited Range

Very useful for normalizing white/black levels across sources.