### PR TITLE
Fix preview mode reset to "Hybrid" if set to "Chroma" and decoder settings are changed

### DIFF
--- a/src/ld-analyse/chromadecoderconfigdialog.cpp
+++ b/src/ld-analyse/chromadecoderconfigdialog.cpp
@@ -135,15 +135,13 @@ void ChromaDecoderConfigDialog::setConfiguration(VideoSystem _system, const PalC
                                                  const Comb::Configuration &_ntscConfiguration,
                                                  const MonoDecoder::MonoConfiguration &_monoConfiguration,
 												 const TbcSource::SourceMode &_mode,
-												 const bool _isInit,
-                                                 const OutputWriter::Configuration &_outputConfiguration)
+												 const bool _isInit)
 {
     const double configuredYNRLevel = _system == NTSC ? _ntscConfiguration.yNRLevel : _palConfiguration.yNRLevel;
     system = _system;
     palConfiguration = _palConfiguration;
     ntscConfiguration = _ntscConfiguration;
     monoConfiguration = _monoConfiguration;
-    outputConfiguration = _outputConfiguration;
 	sourceMode = _mode;
 
     palConfiguration.chromaGain = qBound(0.0, palConfiguration.chromaGain, 2.0);
@@ -183,10 +181,6 @@ const Comb::Configuration &ChromaDecoderConfigDialog::getNtscConfiguration()
     return ntscConfiguration;
 }
 
-const OutputWriter::Configuration &ChromaDecoderConfigDialog::getOutputConfiguration()
-{
-    return outputConfiguration;
-}
 void ChromaDecoderConfigDialog::setVideoLevels(const LdDecodeMetaData::VideoParameters &videoParameters)
 {
     system = videoParameters.system;

--- a/src/ld-analyse/chromadecoderconfigdialog.h
+++ b/src/ld-analyse/chromadecoderconfigdialog.h
@@ -17,7 +17,6 @@
 #include <QSlider>
 
 #include "comb.h"
-#include "outputwriter.h"
 #include "palcolour.h"
 #include "monodecoder.h"
 #include "tbcsource.h"
@@ -38,12 +37,10 @@ public:
                           const Comb::Configuration &ntscConfiguration,
                           const MonoDecoder::MonoConfiguration &monoConfiguration,
                           const TbcSource::SourceMode &_mode,
-						  const bool _isInit,
-                          const OutputWriter::Configuration &outputConfiguration);
+						  const bool _isInit);
     void setVideoLevels(const LdDecodeMetaData::VideoParameters &videoParameters);
     const PalColour::Configuration &getPalConfiguration();
     const Comb::Configuration &getNtscConfiguration();
-    const OutputWriter::Configuration &getOutputConfiguration();
 
 signals:
     void chromaDecoderConfigChanged();
@@ -86,7 +83,6 @@ private:
     PalColour::Configuration palConfiguration;
     Comb::Configuration ntscConfiguration;
     MonoDecoder::MonoConfiguration monoConfiguration;
-    OutputWriter::Configuration outputConfiguration;
 	TbcSource* tbcSource = nullptr;
 	TbcSource::SourceMode sourceMode;
 	bool isInit = true;

--- a/src/ld-analyse/mainwindow.cpp
+++ b/src/ld-analyse/mainwindow.cpp
@@ -2131,8 +2131,7 @@ void MainWindow::resetGui()
                                                 tbcSource.getNtscConfiguration(),
                                                 tbcSource.getMonoConfiguration(),
                                                 tbcSource.getSourceMode(),
-												true,//set to true because the chroma decoder is already init
-												tbcSource.getOutputConfiguration());
+                                                true); // set to true because the chroma decoder is already init
     chromaDecoderConfigDialog->setVideoLevels(tbcSource.getVideoParameters());
 }
 
@@ -2172,8 +2171,7 @@ void MainWindow::updateGuiLoaded()
                                                 tbcSource.getNtscConfiguration(),
                                                 tbcSource.getMonoConfiguration(),
                                                 tbcSource.getSourceMode(),
-												false,//set to false to init the chroma decoder selection
-												tbcSource.getOutputConfiguration());
+                                                false); // set to false to init the chroma decoder selection
     chromaDecoderConfigDialog->setVideoLevels(tbcSource.getVideoParameters());
 
     // Ensure the busy dialogue is hidden
@@ -7179,9 +7177,7 @@ void MainWindow::chromaDecoderConfigChangedSignalHandler()
     const PalColour::Configuration &palConfig = chromaDecoderConfigDialog->getPalConfiguration();
     const Comb::Configuration &ntscConfig = chromaDecoderConfigDialog->getNtscConfiguration();
     // Set the new configuration
-    tbcSource.setChromaConfiguration(palConfig,
-                                     ntscConfig,
-                                     chromaDecoderConfigDialog->getOutputConfiguration());
+    tbcSource.setChromaConfiguration(palConfig, ntscConfig);
 
     LdDecodeMetaData::VideoParameters videoParameters = tbcSource.getVideoParameters();
     videoParameters.chromaGain = palConfig.chromaGain;

--- a/src/ld-analyse/tbcsource.cpp
+++ b/src/ld-analyse/tbcsource.cpp
@@ -1652,22 +1652,13 @@ qint32 TbcSource::getCcData1() const
 }
 
 void TbcSource::setChromaConfiguration(const PalColour::Configuration &_palConfiguration,
-                                       const Comb::Configuration &_ntscConfiguration,
-                                       const OutputWriter::Configuration &_outputConfiguration)
+                                       const Comb::Configuration &_ntscConfiguration)
 {
     ntscColour.requestNnTransform3DCancel();
     invalidateImageCache();
 
     palConfiguration = _palConfiguration;
     ntscConfiguration = _ntscConfiguration;
-    outputConfiguration = _outputConfiguration;
-    if (outputConfiguration.trimToActiveRegion) {
-        chromaDecodeMode = ACTIVE_ONLY_CHROMA_MODE;
-    } else if (outputConfiguration.fullFrameDecode) {
-        chromaDecodeMode = FULL_FRAME_CHROMA_MODE;
-    } else {
-        chromaDecodeMode = HYBRID_CHROMA_MODE;
-    }
 
     configureChromaDecoder();
 }

--- a/src/ld-analyse/tbcsource.h
+++ b/src/ld-analyse/tbcsource.h
@@ -169,8 +169,7 @@ public:
     qint32 getCcData0() const;
     qint32 getCcData1() const;
 
-    void setChromaConfiguration(const PalColour::Configuration &palConfiguration, const Comb::Configuration &ntscConfiguration,
-                                const OutputWriter::Configuration &outputConfiguration);
+    void setChromaConfiguration(const PalColour::Configuration &palConfiguration, const Comb::Configuration &ntscConfiguration);
     void requestNnTransform3DCancel();
     const PalColour::Configuration &getPalConfiguration() const;
     const Comb::Configuration &getNtscConfiguration() const;


### PR DESCRIPTION
## Bug:

**When the preview is set to "Chroma" (as opposed to Mono or Hybrid), changing any settings in the Video Decoder Configuration window would reset the preview to "Hybrid" even if Chroma was selected.**

Codex Summary:

---

### Summary

Fixes an issue where changing any NTSC option in **Video Decoder Configuration** could reset the preview mode from **Chroma** back to **Hybrid**.

The underlying problem was that `ChromaDecoderConfigDialog` kept its own cached copy of `OutputWriter::Configuration`. The preview button updates the active preview mode through `TbcSource::setChromaDecodeMode()`, but the config dialog’s cached output configuration was not updated at the same time. When an NTSC setting changed, the dialog passed that stale output configuration back into `TbcSource`, causing `setChromaConfiguration()` to reconstruct the chroma decode mode as Hybrid.

### Fix

This separates decoder configuration from preview/output mode ownership:

- `ChromaDecoderConfigDialog` no longer stores or returns `OutputWriter::Configuration`.
- `TbcSource::setChromaConfiguration()` now updates only PAL/NTSC decoder settings.
- Preview mode remains owned by `TbcSource::setChromaDecodeMode()`.

This removes the stale state path instead of preserving/restoring the mode after the fact, so changing decoder settings no longer mutates the selected preview mode.

### Notes

No intended change to decoder behavior. This only prevents unrelated decoder configuration changes from overwriting the current preview mode.

---