### PR TITLE
Video Paramters window: Show frame size, fix incorrect wording

### DIFF
--- a/src/ld-analyse/videoparametersdialog.cpp
+++ b/src/ld-analyse/videoparametersdialog.cpp
@@ -14,6 +14,7 @@
 #include <QSignalBlocker>
 #include <QSlider>
 #include <QSpinBox>
+#include <QString>
 #include <QWheelEvent>
 
 namespace {
@@ -119,6 +120,13 @@ bool VideoParametersDialog::eventFilter(QObject *object, QEvent *event)
     return QDialog::eventFilter(object, event);
 }
 
+void VideoParametersDialog::updateResultingFrameSizeLabel()
+{
+    const qint32 width = videoParameters.activeVideoEnd - videoParameters.activeVideoStart;
+    const qint32 height = videoParameters.lastActiveFrameLine - videoParameters.firstActiveFrameLine;
+    ui->resultingFrameSizeValueLabel->setText(QString("%1 x %2").arg(width).arg(height));
+}
+
 void VideoParametersDialog::setVideoParameters(const LdDecodeMetaData::VideoParameters &_videoParameters)
 {
     videoParameters = _videoParameters;
@@ -205,6 +213,8 @@ void VideoParametersDialog::setVideoParameters(const LdDecodeMetaData::VideoPara
     if (videoParameters.isWidescreen) ui->aspectRatio169RadioButton->setChecked(true);
     else ui->aspectRatio43RadioButton->setChecked(true);
 
+    updateResultingFrameSizeLabel();
+
     // Unblock signals
     ui->activeVideoWidthSpinBox->blockSignals(false);
     ui->activeVideoStartSpinBox->blockSignals(false);
@@ -243,6 +253,7 @@ void VideoParametersDialog::on_activeVideoStartSpinBox_valueChanged(int value)
         QSignalBlocker blocker(ui->activeVideoStartHorizontalSlider);
         ui->activeVideoStartHorizontalSlider->setValue(value);
     }
+    updateResultingFrameSizeLabel();
     emit videoParametersChanged(videoParameters);
 }
 
@@ -253,6 +264,7 @@ void VideoParametersDialog::on_activeVideoWidthSpinBox_valueChanged(int value)
         QSignalBlocker blocker(ui->activeVideoWidthHorizontalSlider);
         ui->activeVideoWidthHorizontalSlider->setValue(value);
     }
+    updateResultingFrameSizeLabel();
     emit videoParametersChanged(videoParameters);
 }
 
@@ -319,6 +331,7 @@ void VideoParametersDialog::on_firstActiveFrameLineSpinBox_valueChanged(int valu
         QSignalBlocker blocker(ui->firstActiveFrameLineHorizontalSlider);
         ui->firstActiveFrameLineHorizontalSlider->setValue(value);
     }
+    updateResultingFrameSizeLabel();
     emit videoParametersChanged(videoParameters);
 }
 
@@ -332,6 +345,7 @@ void VideoParametersDialog::on_lastActiveFrameLineSpinBox_valueChanged(int value
         QSignalBlocker blocker(ui->lastActiveFrameLineHorizontalSlider);
         ui->lastActiveFrameLineHorizontalSlider->setValue(value);
     }
+    updateResultingFrameSizeLabel();
     emit videoParametersChanged(videoParameters);
 }
 

--- a/src/ld-analyse/videoparametersdialog.h
+++ b/src/ld-analyse/videoparametersdialog.h
@@ -66,6 +66,8 @@ private slots:
     void on_exportBoundaryThicknessHorizontalSlider_valueChanged(int value);
 
 private:
+    void updateResultingFrameSizeLabel();
+
     Ui::VideoParametersDialog *ui;
     LdDecodeMetaData::VideoParameters videoParameters;
     qint32 originalActiveVideoStart = -1;

--- a/src/ld-analyse/videoparametersdialog.ui
+++ b/src/ld-analyse/videoparametersdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>520</width>
-    <height>520</height>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -175,7 +175,7 @@
    <item row="4" column="0">
     <widget class="QLabel" name="firstActiveFieldLineLabel">
      <property name="text">
-      <string>First active field line:</string>
+      <string>Active field start line:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -233,7 +233,7 @@
    <item row="6" column="0">
     <widget class="QLabel" name="lastActiveFieldLineLabel">
      <property name="text">
-      <string>Last active field line:</string>
+      <string>Active field end line (excl.):</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -291,7 +291,7 @@
    <item row="8" column="0">
     <widget class="QLabel" name="firstActiveFrameLineLabel">
      <property name="text">
-      <string>First active frame line:</string>
+      <string>Active frame start line:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -349,7 +349,7 @@
    <item row="10" column="0">
     <widget class="QLabel" name="lastActiveFrameLineLabel">
      <property name="text">
-      <string>Last active frame line:</string>
+      <string>Active frame end line (excl.):</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -405,6 +405,32 @@
     </widget>
    </item>
    <item row="12" column="0">
+    <widget class="QLabel" name="resultingFrameSizeLabel">
+     <property name="text">
+      <string>Resulting frame size:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1" colspan="2">
+    <widget class="QLabel" name="resultingFrameSizeValueLabel">
+     <property name="minimumSize">
+      <size>
+       <width>70</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>0 x 0</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
     <widget class="QLabel" name="aspectRatioLabel">
      <property name="text">
       <string>Display aspect ratio:</string>
@@ -414,7 +440,7 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="1" colspan="2">
+   <item row="13" column="1" colspan="2">
     <widget class="QWidget" name="aspectRatioWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
@@ -468,14 +494,14 @@
      </layout>
     </widget>
    </item>
-   <item row="13" column="0" colspan="3">
+   <item row="14" column="0" colspan="3">
     <widget class="QCheckBox" name="exportBoundaryCheckBox">
      <property name="text">
       <string>Show export boundary</string>
      </property>
     </widget>
    </item>
-   <item row="14" column="0">
+   <item row="15" column="0">
     <widget class="QLabel" name="exportBoundaryThicknessLabel">
      <property name="text">
       <string>Boundary thickness (px):</string>
@@ -485,7 +511,7 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="1">
+   <item row="15" column="1">
     <widget class="QSpinBox" name="exportBoundaryThicknessSpinBox">
      <property name="minimumSize">
       <size>
@@ -507,7 +533,7 @@
      </property>
     </widget>
    </item>
-   <item row="15" column="1" colspan="2">
+   <item row="16" column="1" colspan="2">
     <widget class="QSlider" name="exportBoundaryThicknessHorizontalSlider">
      <property name="minimumSize">
       <size>


### PR DESCRIPTION
- Added a label that shows the resulting frame size (e.g. `760 x 485`) based on the current active video area settings
- Fixed incorrect wording: "Last active line" renamed to "Active field end (excl.)" to clarify that this number is *exclusive*. The previous wording, "last active", implied that it would be included, which is not the case.

<img width="445" height="539" alt="image" src="https://github.com/user-attachments/assets/bac11830-01a3-4bbe-b764-b2ff3bb97efc" />
